### PR TITLE
Fix so loading doesn't fail w/o validator.

### DIFF
--- a/shop3/pddl/pddl.lisp
+++ b/shop3/pddl/pddl.lisp
@@ -69,7 +69,11 @@
 (defparameter +fluent-updates+
   '(assign increase decrease scale-up scale-down))
 
-(defvar *validator-progname* (truename (asdf:system-relative-pathname "shop3" "../jenkins/VAL/validate")))
+(defvar *validator-progname*
+  (let ((local-validator (asdf:system-relative-pathname "shop3" "../jenkins/VAL/validate")))
+    (if (probe-file local-validator)
+        (truename local-validator))
+    "validate"))
 
 (defgeneric validator-export (domain plan stream)
   (:documentation "Print a plan in a way that it can be consumed by


### PR DESCRIPTION
I made a prior fix to make the tests work, that would prefer a local copy of the validator program (from `jenkins/ext/VAL`).  But I didn't realize that would cause loading to fail if the validator had not been built. This patch fixes that.