### PR TITLE
Permit state description argument to QUERY.

### DIFF
--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -193,7 +193,7 @@ fi
 # before we do the following...[2019/04/23:rpg]
 SHOP3DIR="$(cd ../shop3 ; /bin/pwd)"
 THISDIR="$(pwd)"
-PATH=${THISDIR}/ext/VAL:$PATH
+PATH=${THISDIR}/VAL:$PATH
 type -P validate 2>/dev/null
 if [[ $? != 0 ]];
 then

--- a/shop3/common/state-decls.lisp
+++ b/shop3/common/state-decls.lisp
@@ -30,6 +30,14 @@
 ;;; make-initial-state
 
 ;;;---------------------------------------------------------------------------
+;;; Class that is the core of all domain objects
+;;;---------------------------------------------------------------------------
+(defclass domain-core ()
+  ()
+  (:documentation "Core class that is the parent of all domain classes, both
+theorem-prover and SHOP3."))
+
+;;;---------------------------------------------------------------------------
 ;;; Generic function declarations
 ;;;---------------------------------------------------------------------------
 ;; this is the new initial state creation function which dispatches

--- a/shop3/io/input.lisp
+++ b/shop3/io/input.lisp
@@ -585,7 +585,7 @@ breaks usage of *load-truename* by moving the FASLs.")
   "Find and return a domain object with the name NAME.  Will return
 the value in its IF-NOT-FOUND argument if no such domain is loaded.
 IF-NOT-FOUND defaults to :error, which will raise an error condition."
-  (if (typep name-or-obj 'domain)
+  (if (typep name-or-obj 'domain-core)
       name-or-obj
       (let ((domain (get name-or-obj :domain)))
         (cond (domain domain)

--- a/shop3/io/input.lisp
+++ b/shop3/io/input.lisp
@@ -594,13 +594,19 @@ IF-NOT-FOUND defaults to :error, which will raise an error condition."
                (error "No domain named ~A" name-or-obj))
               (t if-not-found)))))
 
-;;; make QUERY easier to use
+;;; make QUERY easier to use -- this around method is here because FIND-DOMAIN isn't available in
+;;; the SHOP THEOREM-PROVER system.
 (defmethod shop3.theorem-prover:query :around (goals state &key just-one (domain *domain*)
                                                              (record-dependencies *record-dependencies-p*))
-  (if (symbolp domain)
-      (call-next-method goals state :just-one just-one :domain (find-domain domain)
-                        :record-dependencies record-dependencies)
-      (call-next-method)))
+  (let* ((domain
+           (if (symbolp domain)
+               (find-domain domain)
+               domain))
+         (state (if (listp state)
+                    (make-initial-state domain :mixed state)
+                    state)))
+    (call-next-method goals state :just-one just-one :domain (find-domain domain)
+                                  :record-dependencies record-dependencies)))
   
 
 (defun delete-domain (name)

--- a/shop3/package.lisp
+++ b/shop3/package.lisp
@@ -62,6 +62,7 @@
     (:nicknames :shop :shop2)
     (:use :common-lisp :shop3.unifier :shop3.common :shop3.theorem-prover
           :iterate)
+    (:import-from #:shop3.common #:domain-core)
     (:import-from #:shop3.theorem-prover #:+numerical-comparisons+
                   #:fluent-value
                   #:f-exp-value

--- a/shop3/shop3.asd
+++ b/shop3/shop3.asd
@@ -246,7 +246,7 @@ shop3."
                  (test-plan-repair . :shop-replan-tests) ; 3
                  (test-shop-states . :test-states) ; 110
                  )
-    :num-checks 900 ; got 900 on lispworks.
+    :num-checks 902
     :depends-on ((:version "shop3" (:read-file-form "shop-version.lisp-expr"))
                  "shop3/openstacks"
                  "shop3/pddl-helpers"

--- a/shop3/tests/pddl-tests.lisp
+++ b/shop3/tests/pddl-tests.lisp
@@ -926,6 +926,13 @@
                                         (not (communicate_image_data ?obj ?m)))))
             (make-initial-state *domain* :list (problem-state (find-problem 'test-rover-problem)))
             :record-dependencies nil :domain *domain*))
+    (fiveam:is-false 
+     (query (process-pddl-method-pre *domain*
+                                     '(forall (?obj - objective)
+                                       (forall (?m - mode)
+                                        (not (communicate_image_data ?obj ?m)))))
+            (problem-state (find-problem 'test-rover-problem))
+            :record-dependencies nil :domain *domain*))
     (fiveam:is-true
      (query (process-pddl-method-pre *domain*
                                      '(forall (?obj - objective)
@@ -935,11 +942,26 @@
                                                        (problem-state (find-problem 'test-rover-problem))
                                                        :test 'equalp))
             :record-dependencies nil :domain *domain*))
+    (fiveam:is-true
+     (query (process-pddl-method-pre *domain*
+                                     '(forall (?obj - objective)
+                                       (forall (?m - mode)
+                                        (not (communicate_image_data ?obj ?m)))))
+            (remove '(communicate_image_data objective1 high_res)
+                                                      (problem-state (find-problem 'test-rover-problem))
+                                                      :test 'equalp)
+            :record-dependencies nil :domain *domain*))
     (fiveam:is-false 
      (query (process-pddl-method-pre *domain*
                                      '(forall (?obj - objective ?m - mode)
                                        (not (communicate_image_data ?obj ?m))))
             (make-initial-state *domain* :list (problem-state (find-problem 'test-rover-problem)))
+            :record-dependencies nil :domain *domain*))
+    (fiveam:is-false 
+     (query (process-pddl-method-pre *domain*
+                                     '(forall (?obj - objective ?m - mode)
+                                       (not (communicate_image_data ?obj ?m))))
+            (problem-state (find-problem 'test-rover-problem))
             :record-dependencies nil :domain *domain*))
     (fiveam:is-true
      (query (process-pddl-method-pre *domain*
@@ -948,6 +970,14 @@
             (make-initial-state *domain* :list (remove '(communicate_image_data objective1 high_res)
                                                        (problem-state (find-problem 'test-rover-problem))
                                                        :test 'equalp))
+            :record-dependencies nil :domain *domain*))
+    (fiveam:is-true
+     (query (process-pddl-method-pre *domain*
+                                     '(forall (?obj - objective ?m - mode)
+                                       (not (communicate_image_data ?obj ?m))))
+            (remove '(communicate_image_data objective1 high_res)
+                                                      (problem-state (find-problem 'test-rover-problem))
+                                                      :test 'equalp)
             :record-dependencies nil :domain *domain*))))
 
 

--- a/shop3/tests/theorem-prover-tests.lisp
+++ b/shop3/tests/theorem-prover-tests.lisp
@@ -70,6 +70,10 @@
             (query '(or (foo ?x) (bar ?x))
                    (shop3.common:make-initial-state *domain* (default-state-type *domain*)
                                                     '((foo a) (bar b))))))
+      (is (equal '(a b) (sorted-bindings '?x bindings))))
+    (let ((bindings
+            (query '(or (foo ?x) (bar ?x))
+                   '((foo a) (bar b)))))
       (is (equal '(a b) (sorted-bindings '?x bindings))))))
 
 ;;; what about IMPLY?
@@ -82,11 +86,20 @@
                                                       (foo c)
                                                       (foo d) (bar d))))))
       (is (equal '(a b c) (sorted-bindings '?x bindings))))
+    (let ((bindings
+            (query '(and (foo ?x) (imply (bar ?x) (baz ?x)))
+                   '((foo a) (foo b) (bar b) (baz b)
+                     (foo c)
+                     (foo d) (bar d)))))
+      (is (equal '(a b c) (sorted-bindings '?x bindings))))
     ;; in this context, (NOT (BAR ?X)) has no sensible semantics.  Raise error.
     (signals non-ground-error
      (query '(and (imply (bar ?x) (baz ?x)))
             (shop3.common:make-initial-state *domain* (default-state-type *domain*)
-                                             '((foo a) (foo b) (bar b) (baz b))))))
+                                             '((foo a) (foo b) (bar b) (baz b)))))
+    (signals non-ground-error
+     (query '(and (imply (bar ?x) (baz ?x)))
+            '((foo a) (foo b) (bar b) (baz b)))))
   (with-fixture pddl-tp-domain ()
     (let ((bindings
             (query '(and (foo ?x) (imply (bar ?x) (baz ?x)))
@@ -94,6 +107,12 @@
                                                     '((foo a) (foo b) (bar b) (baz b)
                                                       (foo c)
                                                       (foo d) (bar d))))))
+      (is (equal '(a b c) (sorted-bindings '?x bindings))))
+    (let ((bindings
+            (query '(and (foo ?x) (imply (bar ?x) (baz ?x)))
+                   '((foo a) (foo b) (bar b) (baz b)
+                     (foo c)
+                     (foo d) (bar d)))))
       (is (equal '(a b c) (sorted-bindings '?x bindings))))))
 
 

--- a/shop3/theorem-prover/decls.lisp
+++ b/shop3/theorem-prover/decls.lisp
@@ -132,7 +132,7 @@ function!  Instead, please use the def-logical-keyword macro.")
   (gethash name (domain-axioms domain)))
 
 
-(defclass thpr-domain (has-axioms-mixin)
+(defclass thpr-domain (domain-core has-axioms-mixin)
   (
    (domain-name
     :initarg :domain-name

--- a/shop3/theorem-prover/package-thpr.lisp
+++ b/shop3/theorem-prover/package-thpr.lisp
@@ -61,7 +61,7 @@
 (defpackage :shop3.theorem-prover
     (:nicknames :shopthpr :shop.theorem-prover)
     (:use :common-lisp :shop3.common :shop3.unifier :iterate)
-    (:import-from #:shop3.common #:add-atom-to-state #:state-atoms)
+    (:import-from #:shop3.common #:add-atom-to-state #:state-atoms #:domain-core)
     ;; make these symbols available for import
     (:intern  #:+numerical-comparisons+
               #:fluent-value


### PR DESCRIPTION
Previously, QUERY required a STATE object as argument. Now it will
alternatively accept a state description (list of facts), as well, and
make the required STATE object itself.