### PR TITLE
Set up GitHub actions CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,12 @@ jobs:
       # always run install, since it does some global installs and setup that isn't cached
       env:
        LISP: ${{ matrix.lisp }}
+      # Use a previous release of Roswell to avoid error encountered
+      # due to libcurl3 not being available.
+      # Source of fix: https://github.com/avodonosov/drakma/commit/fbba29181ba2962f5031da581bd2de4dac98733d
       run: |
         sudo apt install -y libcurl4
-        curl -L https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh -x
+        curl -L https://raw.githubusercontent.com/roswell/roswell/a8fd8a3c33078d6f06e6cda9d099dcba6fbefcb7/scripts/install-for-ci.sh | sh
 
     # Prompts Roswell to setup if the selected lisp version, if it has not been setup yet.
     - name: run lisp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,23 @@ jobs:
       run: |
         git submodule update --init --recursive
 
+    - name: cache validate
+      id: cache-validate
+      uses: actions/cache@v2
+      with:
+        path: jenkins/VAL
+        key: ${{ runner.os }}
+
+    - name: compile validate
+      if: steps.cache-validate.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd jenkins/VAL
+        make
+
+    - name: add validate to path
+      run: echo "${GITHUB_WORKSPACE}/jenkins/VAL" >> $GITHUB_PATH
+
     # Lisp setup copied from here: https://github.com/3b/ci-example/blob/master/.github/workflows/CI.yml
     - name: cache .roswell
       id: cache-dot-roswell
@@ -72,17 +89,8 @@ jobs:
         sudo apt install -y libcurl4
         curl -L https://raw.githubusercontent.com/roswell/roswell/a8fd8a3c33078d6f06e6cda9d099dcba6fbefcb7/scripts/install-for-ci.sh | sh
 
-    # Prompts Roswell to setup if the selected lisp version, if it has not been setup yet.
-    - name: run lisp
-      continue-on-error: true
-      shell: bash
-      run: |
-        ros -e '(format t "~a:~a on ~a~%...~%~%" (lisp-implementation-type) (lisp-implementation-version) (machine-type))'
-        ros -e '(format t " fixnum bits:~a~%" (integer-length most-positive-fixnum))'
-        ros -e "(ql:quickload 'trivial-features)" -e '(format t "features = ~s~%" *features*)'
-
     # Compile first in a separate step to make the test output more readable
-    - name: compile
+    - name: compile lisp
       shell: bash
       run: |
         ros -e "(cl:in-package :cl-user)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,7 @@ jobs:
        LISP: ${{ matrix.lisp }}
       run: |
         sudo apt install -y libcurl4
-        curl -L https://github.com/roswell/roswell/releases/download/v19.08.10.101/roswell_19.08.10.101-1_amd64.deb --output roswell.deb
-        sudo dpkg -i roswell.deb
+        curl -L https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh -x
 
     # Prompts Roswell to setup if the selected lisp version, if it has not been setup yet.
     - name: run lisp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
              (typecase test-result
                (fiveam::test-passed nil)
                (fiveam::test-failure t)
+               (null t)
                (list (when (find-if #'test-fail-p test-result) t))
                (t t)))
            (uiop:quit (if (test-fail-p (fiveam:run (quote ${{ matrix.test }}))) 1 0))"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,109 @@
+name: CI
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  test:
+    # The type of runner that the job will run on
+    runs-on: ${{matrix.os}}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        lisp:
+          - ccl
+          - sbcl
+        test:
+          - ARITY-TEST::ALL-SHOP3-INTERNAL-TESTS
+          - PROTECTION-TEST::PROTECTION-TEST
+          - SHOP-REPLAN-TESTS::TEST-PLAN-REPAIR
+          - SHOP-THEOREM-PROVER-TESTS::THEOREM-PROVER-TESTS
+          - SHOP3-OPENSTACKS::PLAN-OPENSTACKS
+          - SHOP3-OPENSTACKS::TEST-OPENSTACKS-ADL
+          - SHOP3-OPENSTACKS::TEST-OPENSTACKS-ADL-explicit-stack-search
+          - SHOP3-USER::BLOCKS-TESTS
+          - SHOP3-USER::ENHANCED-PLAN-TREE
+          - SHOP3-USER::LOGISTICS-TESTS
+          - SHOP3-USER::MINIMAL-SUBTREE-TESTS
+          - SHOP3-USER::MISC-TESTS
+          - SHOP3-USER::SINGLETON-TESTS
+          - SHOP3-USER::UMT-DOMAIN-TESTS
+          - SHOP3::ROVERS-TESTS
+          - SHOP3::SHORT-PDDL-TESTS
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        git submodule update --init --recursive
+
+    # Lisp setup copied from here: https://github.com/3b/ci-example/blob/master/.github/workflows/CI.yml
+    - name: cache .roswell
+      id: cache-dot-roswell
+      uses: actions/cache@v1
+      with:
+        path: ~/.roswell
+        key: ${{ runner.os }}-dot-roswell-${{ matrix.lisp }}-${{ hashFiles('**/*.asd') }}
+        restore-keys: |
+          ${{ runner.os }}-dot-roswell-${{ matrix.lisp }}-
+          ${{ runner.os }}-dot-roswell-
+
+    - name: install roswell
+      shell: bash
+      # always run install, since it does some global installs and setup that isn't cached
+      env:
+       LISP: ${{ matrix.lisp }}
+      run: |
+        sudo apt install -y libcurl4
+        curl -L https://github.com/roswell/roswell/releases/download/v19.08.10.101/roswell_19.08.10.101-1_amd64.deb --output roswell.deb
+        sudo dpkg -i roswell.deb
+
+    - name: run lisp
+      continue-on-error: true
+      shell: bash
+      run: |
+        ros -e '(format t "~a:~a on ~a~%...~%~%" (lisp-implementation-type) (lisp-implementation-version) (machine-type))'
+        ros -e '(format t " fixnum bits:~a~%" (integer-length most-positive-fixnum))'
+        ros -e "(ql:quickload 'trivial-features)" -e '(format t "features = ~s~%" *features*)'
+
+    # Compile first in a separate step to make the test output more readable
+    - name: compile
+      shell: bash
+      run: |
+        ros -e "(cl:in-package :cl-user)
+           (prin1 (lisp-implementation-type)) (terpri) (prin1 (lisp-implementation-version)) (terpri)
+           (prin1 \"${{ matrix.test }}\") (terpri)
+           (asdf:initialize-source-registry  '(:source-registry (:directory \"$PWD/shop3/\") (:tree \"$PWD/jenkins/ext/\") :inherit-configuration))
+           (declaim (optimize (speed 3)))
+           (asdf:load-system :shop3/test)
+           (uiop:quit 0)"
+
+    - name: tests
+      shell: bash
+      run: |
+        ros -e "(cl:in-package :cl-user)
+           (require :asdf)
+           (prin1 (lisp-implementation-type)) (terpri) (prin1 (lisp-implementation-version)) (terpri)
+           (prin1 \"${{ matrix.test }}\") (terpri)
+           (asdf:initialize-source-registry  '(:source-registry (:directory \"$PWD/shop3/\") (:tree \"$PWD/jenkins/ext/\") :inherit-configuration))
+           (declaim (optimize (speed 3)))
+           (asdf:load-system :shop3/test)
+           (defun test-fail-p (test-result)
+             (typecase test-result
+               (fiveam::test-passed nil)
+               (fiveam::test-failure t)
+               (list (when (find-if #'test-fail-p test-result) t))
+               (t t)))
+           (uiop:quit (if (test-fail-p (fiveam:run (quote ${{ matrix.test }}))) 1 0))"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       # due to libcurl3 not being available.
       # Source of fix: https://github.com/avodonosov/drakma/commit/fbba29181ba2962f5031da581bd2de4dac98733d
       run: |
-        sudo apt install -y libcurl4
+        sudo apt-get install -y libcurl4
         curl -L https://raw.githubusercontent.com/roswell/roswell/a8fd8a3c33078d6f06e6cda9d099dcba6fbefcb7/scripts/install-for-ci.sh | sh
 
     # Compile first in a separate step to make the test output more readable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
         curl -L https://github.com/roswell/roswell/releases/download/v19.08.10.101/roswell_19.08.10.101-1_amd64.deb --output roswell.deb
         sudo dpkg -i roswell.deb
 
+    # Prompts Roswell to setup if the selected lisp version, if it has not been setup yet.
     - name: run lisp
       continue-on-error: true
       shell: bash


### PR DESCRIPTION
Adds a translation of the Travis CI config to a Github Actions config.

Differences:
- Uses `Roswell` instead of `cl-travis` just because there was a example Roswell easily available to start from. I think `Roswell` and `cl-travis` are equivalent for this testing environment. If there is a reason to prefer `cl-travis`, I can update the CI config to use that instead.
- A bug was found in the test result checking condition. When `fiveam` runs a suite, it returns a list of test results instead of a single test result. The Travis config was checking the if the result was a test failure. This check misses failures when a test suite is run since the `fiveam` return value, a list of results, is not equal a test failure object. Fixing this check revealed some tests are currently failing on the master branch.

Possible Improvements:
- I didn't spend much time trying to optimize the setup of the environment. If time credits start to become an issue, there's likely room to improve this CI config to reduce the time spent setting up.
- Windows and Mac could be added as target OSes. I'm not sure there is much benefit to running the tests in those environments. I believe Windows and Mac environments have a significantly higher time credit cost cost that the Ubuntu environment, which probably makes it less appealing to run extra tests for them.