### PR TITLE
Increase timeout of Travis CI tests to 50 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
   - pushd  ${TRAVIS_BUILD_DIR}/jenkins/VAL && make && popd 
 
 script:
-  - cl -e "(cl:in-package :cl-user)
+  - travis_wait 50 cl -e "(cl:in-package :cl-user)
            (prin1 (lisp-implementation-type)) (terpri) (prin1 (lisp-implementation-version)) (terpri)
            (prin1 \"${PKG}::${SUITE}\") (terpri)
            (asdf:initialize-source-registry  '(:source-registry (:directory \"$TRAVIS_BUILD_DIR/shop3/\") (:tree \"$TRAVIS_BUILD_DIR/jenkins/ext/\") :inherit-configuration))

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ produce the manual in HTML, Emacs info, and PDF formats.
 
 ## Questions
 
-If you have questions, please post them using the (Discussions)[https://github.com/shop-planner/shop3/discussions] link.
+If you have questions, please post them using the [Discussions](https://github.com/shop-planner/shop3/discussions) link.
 
 Now that GitHub has added discussions, we would prefer to keep issues for actual bug reports.
 


### PR DESCRIPTION
Two tests are currently failing when run by Travis. The failure seems to be due to Travis timing out tests that do not produce output for 10 minutes. The two failing tests are longer running tests. The timeout has been increased to 50 minutes to see if that gives the tests enough time to finish.

Example failing job: https://travis-ci.com/github/shop-planner/shop3/jobs/498842611

Relevant Travis documentation: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received