### PR TITLE
Two small changes made while developing MCTS

### DIFF
--- a/shop3/planning-engine/search.lisp
+++ b/shop3/planning-engine/search.lisp
@@ -370,10 +370,7 @@ of SHOP2."
              (dump-previous-plans!)))
           (when acceptable-cost
             (trace-print :plans nil state "~4TStoring new plan in *plans-found*~%")
-            (store-plan! domain which-plans final-plan state unifier)
-            ;; (break "What's in *plans-found* now: ~s" *plans-found*)
-            ;; (trace-print :plans nil state "~4TAfter storage, length of *plans-found* is ~d~%" (length *plans-found*))
-            )))))
+            (store-plan! domain which-plans final-plan state unifier))))))
 
 (defgeneric store-plan! (domain which-plans plan state unifier)
   (:method ((domain domain) (which-plans symbol) plan state unifier)

--- a/shop3/planning-engine/task-reductions.lisp
+++ b/shop3/planning-engine/task-reductions.lisp
@@ -417,9 +417,11 @@ Otherwise it returns FAIL."
       (append previous (list (first unordered-list)))))))
 
 (defun get-task-name (task1)
-  (if (eq (second task1) :immediate)
-    (third task1)
-    (second task1)))
+  (cond ((eq (first task1) :task)
+         (if (eq (second task1) :immediate)
+             (third task1)
+             (second task1)))
+        (t (first task1))))
 
 (defun get-task-body (task1)
   (if (eq (second task1) :immediate)


### PR DESCRIPTION
While developing the Monte Carlo Tree Search SHOP variant, I encountered a couple of issues:

1. Wanted to modify `store-plan!`, so made it a generic function.
2. Needed `get-task-plan` to be more robust.