### PR TITLE
A number of extensions I made in the process of doing SHOP-MCTS

### DIFF
--- a/shop3/common/state-utils.lisp
+++ b/shop3/common/state-utils.lisp
@@ -56,7 +56,7 @@
 ;;; expiration date shown above. Any reproduction of the software or
 ;;; portions thereof marked with this legend must also reproduce the
 ;;; markings.
-(in-package :shop2.common)
+(in-package :shop.common)
 
 
 

--- a/shop3/planning-engine/task-reductions.lisp
+++ b/shop3/planning-engine/task-reductions.lisp
@@ -419,6 +419,9 @@ Otherwise it returns FAIL."
       (append previous (list (first unordered-list)))))))
 
 (defun get-task-name (task1)
+  "Return the name of the TASK in a task expression.
+This is more than just taking the first element because that
+could be :TASK, could be modified by :IMMEDIATE, etc."
   (cond ((eq (first task1) :task)
          (if (eq (second task1) :immediate)
              (third task1)


### PR DESCRIPTION
Add DOMAIN-ITEMS -- cache source form of the items. Makes them easier to transfer to another domain.
Add METHOD-DEFINITION-KEYWORDS -- Replace constant with generic function to allow developers of new domain classes to add new keywords to the set of allowable keywords.