### PR TITLE
Fix bugs in Iterative-Deepening search

### DIFF
--- a/shop3/decls.lisp
+++ b/shop3/decls.lisp
@@ -150,6 +150,10 @@ of EXTRACT-PLAN-TREES.  Generally should be NIL.")
 (declaim (type (or null (function () (values &optional)))
                *before-extract-trees-hook*))
 
+(defvar *old-depth* 0
+  "For iterative-deepening search, what was the maximum depth of the last iteration,
+so we can avoid duplicate plans.")
+
 
 ;;;------------------------------------------------------------------------------------------------------
 ;;; Compiler Directives and Macros

--- a/shop3/planning-engine/search.lisp
+++ b/shop3/planning-engine/search.lisp
@@ -318,6 +318,7 @@ of SHOP2."
   (let ((acceptable-cost (acceptable-cost-p partial-plan-cost))
         (final-plan (strip-NOPs (reverse partial-plan))))
 
+    ;; FIXME: Strip out the optimize variables when they are not relevant.
     (trace-print :plans nil state
                  "~2%Depth ~D, have found a plan with cost ~D~%*optimize-cost* = ~S, *optimal-cost* = ~A~%"
                  depth partial-plan-cost
@@ -371,6 +372,14 @@ of SHOP2."
              (when (not (equal *depth-cutoff* depth))
                (dump-previous-plans!)
                (setq *depth-cutoff* depth)))
+            ((eq which-plans :id-all)
+             ; we need to avoid redundant plans...
+             (trace-print :plans nil state "Checking for redundant plans: depth is ~d, depth cutoff is ~d and old-depth is ~d~%"
+                          depth *depth-cutoff* *old-depth*)
+             (when (<= depth *old-depth*)
+               (trace-print :plans nil state "Ignoring rederivation of plan found at depth ~d previously found below depth ~d~%" depth *old-depth*)
+               (return-from seek-plans-null nil))
+             (trace-print :plans nil state "Plan is not redundant by depth criterion.~%"))
             ((eq which-plans :shallowest)
              (setq *depth-cutoff* (1- depth))
              (dump-previous-plans!)))

--- a/shop3/shop3.asd
+++ b/shop3/shop3.asd
@@ -299,7 +299,9 @@ shop3."
                                (:file "analogical-replay")
                                (:file "minimal-subtree-tests")
                                (:file "sort-by-tests") ; 7 checks
-                               (:file "plan-tree-tests")))                  ; 13 checks
+                               (:file "plan-tree-tests")                  ; 40 checks
+                               (:file "search-tests") ; 9 checks
+                               ))
                  ;;; FIXME: put these tests in a separate package, instead of in SHOP3-USER [2012/09/05:rpg]
                  (:module "shop-umt"
                           :pathname "examples/UMT2/"

--- a/shop3/shop3.asd
+++ b/shop3/shop3.asd
@@ -256,8 +256,9 @@ shop3."
                  (test-shop-states . :test-states) ; 110
                  (analogical-replay-tests . :analogical-replay-tests) ; 24
                  (plan-tree-tests . :plan-tree-tests)  ; 40
+                 (search-tests . :search-tests) ; 9
                  )
-    :num-checks 1044
+    :num-checks 1053
     :depends-on ((:version "shop3" (:read-file-form "shop-version.lisp-expr"))
                  "shop3/openstacks"
                  "shop3/pddl-helpers"

--- a/shop3/shop3.asd
+++ b/shop3/shop3.asd
@@ -298,8 +298,7 @@ shop3."
                                (:file "analogical-replay")
                                (:file "minimal-subtree-tests")
                                (:file "sort-by-tests") ; 7 checks
-                               (:file "plan-tree-tests"))  ; 13 checks
-                  )
+                               (:file "plan-tree-tests")))                  ; 13 checks
                  ;;; FIXME: put these tests in a separate package, instead of in SHOP3-USER [2012/09/05:rpg]
                  (:module "shop-umt"
                           :pathname "examples/UMT2/"

--- a/shop3/shop3.lisp
+++ b/shop3/shop3.lisp
@@ -220,9 +220,8 @@ MPL/GPL/LGPL triple license.  For details, see the software source file.")
 
 (defun find-plans-1 (domain state tasks which problem &key (out-stream t) &allow-other-keys)
   (let ((total-expansions 0) (total-inferences 0)
-         (old-expansions 0) (old-inferences 0)
-         (total-run-time 0) (total-real-time 0)
-        new-run-time new-real-time top-tasks)
+        (total-run-time 0) (total-real-time 0)
+        top-tasks)
 
 
     ;; we need to be sure that the pieces of the input tasks are
@@ -246,38 +245,11 @@ MPL/GPL/LGPL triple license.  For details, see the software source file.")
     (catch 'user-done
       (ecase which
         ((:id-first :id-all)
-         (print-stats-header "Depth" out-stream)
-         (do ((*depth-cutoff* 0 (1+ *depth-cutoff*)))
-             ((or (time-expired-p)      ;need to check here for expired time....
-                  (and *plans-found*
-                       ;; I think the second disjunct here is probably
-                       ;; unnecessary now [2005/01/10:rpg]
-                       (not (or (optimize-continue-p (if (eq which :id-first) :first :all))
-                                (eq which :id-all)))))
-              nil)
-           (setq new-run-time (get-internal-run-time)
-                 new-real-time (get-internal-real-time))
-           (catch-internal-time
-            (seek-plans domain state tasks top-tasks nil 0 0
-                        (if (eq which :id-first) :first :all)
-                        nil nil))
-           (setq new-run-time (- (get-internal-run-time) new-run-time)
-                 new-real-time (- (get-internal-real-time) new-real-time)
-                 total-run-time (+ total-run-time new-run-time)
-                 total-real-time (+ total-real-time new-real-time)
-                 total-expansions (+ total-expansions *expansions*)
-                 total-inferences (+ total-inferences *inferences*))
-           (print-stats *depth-cutoff* *plans-found* *expansions*
-                        *inferences* new-run-time new-real-time out-stream)
-           (and (equal *expansions* old-expansions)
-                (equal *inferences* old-inferences)
-                (progn (format t "~&Ending at depth ~D: no new expansions or inferences.~%"
-                               *depth-cutoff*)
-                       (return nil)))           ; abort if nothing new happened on this iteration
-           (setq old-expansions *expansions*
-                 old-inferences *inferences*)
-           (setq *expansions* 0
-                 *inferences* 0)))
+         (multiple-value-setq (total-run-time
+                               total-real-time
+                               total-expansions
+                               total-inferences)
+           (id-search domain state tasks top-tasks which out-stream)))
 
         ((:first :all :shallowest :all-shallowest :random)
          (catch-internal-time
@@ -332,6 +304,54 @@ MPL/GPL/LGPL triple license.  For details, see the software source file.")
                         (/ total-run-time
                            internal-time-units-per-second))))))))
 
+;;; Helper funcdtion for iterative deepening search.
+(declaim (ftype (domain state cons cons symbol (or stream t) &key (:depth-increment integer))
+                (values (integer 0) (integer 0)
+                        (integer 0) (integer 0) &optional)
+                id-search))
+(defun id-search (domain state tasks top-tasks which out-stream
+                  &key (depth-increment 1))
+  (print-stats-header "Depth" out-stream)
+  (let ((old-expansions 0) (old-inferences 0)
+        (total-run-time 0) (total-real-time 0)
+        (total-expansions 0) (total-inferences 0)
+        (*old-depth* -1))
+   (iter (for *depth-cutoff* from 0 by depth-increment)
+     (until (or (time-expired-p) ;need to check here for expired time....
+                (and *plans-found*
+                     ;; I think the second disjunct here is probably
+                     ;; unnecessary now [2005/01/10:rpg]
+                     (not (or (optimize-continue-p (if (eq which :id-first) :first :all))
+                              (eq which :id-all))))))
+     (for new-run-time = (get-internal-run-time))
+     (as new-real-time = (get-internal-real-time))
+     (catch-internal-time
+      (seek-plans domain state tasks top-tasks nil 0 0
+                  which
+                  nil nil))
+     (setq new-run-time (- (get-internal-run-time) new-run-time)
+           new-real-time (- (get-internal-real-time) new-real-time)
+           total-run-time (+ total-run-time new-run-time)
+           total-real-time (+ total-real-time new-real-time)
+           total-expansions (+ total-expansions *expansions*)
+           total-inferences (+ total-inferences *inferences*))
+     (print-stats *depth-cutoff* *plans-found* *expansions*
+                  *inferences* new-run-time new-real-time out-stream)
+     (and (equal *expansions* old-expansions)
+          (equal *inferences* old-inferences)
+          (progn (format t "~&Ending at depth ~D: no new expansions or inferences.~%"
+                         *depth-cutoff*)
+                 (return nil))) ; abort if nothing new happened on this iteration
+     (setf old-expansions *expansions*
+           old-inferences *inferences*)
+     (setf *expansions* 0
+           *inferences* 0
+           *old-depth* *depth-cutoff*)
+     (finally
+      (return
+       (values total-run-time total-real-time
+               total-expansions total-inferences))))))
+
 (defun extract-trees (plans-found unifiers-found)
   (when *before-extract-trees-hook*
     (funcall *before-extract-trees-hook*))
@@ -347,5 +367,3 @@ MPL/GPL/LGPL triple license.  For details, see the software source file.")
 
 ;; (eval-when (:compile-toplevel)
 ;; (warn "Bogus warning."))
-
-

--- a/shop3/shop3.lisp
+++ b/shop3/shop3.lisp
@@ -305,9 +305,9 @@ MPL/GPL/LGPL triple license.  For details, see the software source file.")
                            internal-time-units-per-second))))))))
 
 ;;; Helper funcdtion for iterative deepening search.
-(declaim (ftype (domain state cons cons symbol (or stream t) &key (:depth-increment integer))
-                (values (integer 0) (integer 0)
-                        (integer 0) (integer 0) &optional)
+(declaim (ftype (function (domain state cons cons symbol (or stream t) &key (:depth-increment integer))
+                          (values (integer 0) (integer 0)
+                                  (integer 0) (integer 0) &optional))
                 id-search))
 (defun id-search (domain state tasks top-tasks which out-stream
                   &key (depth-increment 1))
@@ -337,11 +337,12 @@ MPL/GPL/LGPL triple license.  For details, see the software source file.")
            total-inferences (+ total-inferences *inferences*))
      (print-stats *depth-cutoff* *plans-found* *expansions*
                   *inferences* new-run-time new-real-time out-stream)
-     (and (equal *expansions* old-expansions)
-          (equal *inferences* old-inferences)
-          (progn (format t "~&Ending at depth ~D: no new expansions or inferences.~%"
-                         *depth-cutoff*)
-                 (return nil))) ; abort if nothing new happened on this iteration
+     (when (and (equal *expansions* old-expansions)
+           (equal *inferences* old-inferences))
+       (when (> *verbose* 0)
+        (format t "~&ID-SEARCH: Ending at depth ~D: no new expansions or inferences.~%"
+                *depth-cutoff*))
+       (finish)) ; abort if nothing new happened on this iteration
      (setf old-expansions *expansions*
            old-inferences *inferences*)
      (setf *expansions* 0

--- a/shop3/tests/search-tests.lisp
+++ b/shop3/tests/search-tests.lisp
@@ -1,0 +1,75 @@
+(defpackage :search-tests
+  (:shadow #:fail)
+  (:import-from :alexandria #:set-equal)
+  (:use :shop3 :common-lisp :fiveam))
+
+(in-package :search-tests)
+
+(def-suite* search-tests)
+
+(def-fixture sort-by-domain ()
+  (let ((shop:*define-silently* t))
+   (defdomain sort-by
+       ((:method (sorting)
+          (:sort-by ?v
+                    (alt ?x ?v))
+          (!choose-alt ?x))
+
+        (:op (!choose-alt ?x)
+         :add ((chosen ?x))))))
+  (&body))
+
+(def-fixture simple-sort-by-problem ()
+  (let ((shop:*define-silently* t))
+    ;; for some reason the following isn't quashing the warnings [2022/11/01:rpg]
+    (#+allegro excl:without-redefinition-warnings
+     #-allegro progn
+     (defproblem (simple-sort-by :redefine-ok t)
+         ((alt a 1)
+          (alt b 2)
+          (alt c 3))
+       (sorting))))
+  (&body))
+
+(test sort-all
+  (let ((plans
+          (with-fixture sort-by-domain ()
+            (with-fixture simple-sort-by-problem ()
+              (find-plans 'simple-sort-by
+                          :domain 'sort-by
+                          :which :all
+                          :verbose 0)))))
+    (is-true plans)
+    (is (= 3 (length plans)))
+    (is (set-equal '(((!choose-alt a)) ((!choose-alt b)) ((!choose-alt c)))
+                   (mapcar #'shorter-plan plans)
+                   :test 'equalp))))
+
+
+(test sort-all-stack
+  (let ((plans
+          (with-fixture sort-by-domain ()
+            (with-fixture simple-sort-by-problem ()
+              (find-plans-stack 'simple-sort-by
+                          :domain 'sort-by
+                          :which :all
+                          :verbose 0)))))
+    (is-true plans)
+    (is (= 3 (length plans)))
+    (is (set-equal '(((!choose-alt a)) ((!choose-alt b)) ((!choose-alt c)))
+                   (mapcar #'shorter-plan plans)
+                   :test 'equalp))))
+
+(test sort-all-iterative-deepening
+  (let ((plans
+          (with-fixture sort-by-domain ()
+            (with-fixture simple-sort-by-problem ()
+              (find-plans 'simple-sort-by
+                          :domain 'sort-by
+                          :which :id-all
+                          :verbose 0)))))
+    (is-true plans)
+    (is (= 3 (length plans)))
+    (is (set-equal '(((!choose-alt a)) ((!choose-alt b)) ((!choose-alt c)))
+                   (mapcar #'shorter-plan plans)
+                   :test 'equalp))))


### PR DESCRIPTION
Previously, :ID-ALL would return redundant sets of plans, repeatedly
storing ones that were generated at shallower depths. Fix this by
checking to ensure that a newly-found plan was not found at a depth
below the current depth increment.