### PR TITLE
Add explicit dependency between shop-pddl-tests and warns-check.lisp

### DIFF
--- a/shop3/shop3.asd
+++ b/shop3/shop3.asd
@@ -266,12 +266,14 @@ shop3."
     :version (:read-file-form "shop-version.lisp-expr")
     :components ((:module "shop-test-helper"
                           :pathname "tests/"
-                          :components ((:file "common")))
+                          :components ((:file "common")
+                                       (:file "warns-check")))
 
                  (:file "silent-shop-test")
                  (:file "theorem-prover-tests"
                         :pathname "tests/theorem-prover-tests")
                  (:module "shop-pddl-tests"
+                          :depends-on ("shop-test-helper")
                           :pathname "tests/"
                           :components ((:file "pddl-tests")))
                  (:module "shop-protection-tests"
@@ -282,8 +284,7 @@ shop3."
                  (:module "shop-internal-tests"
                   :depends-on ("shop-logistic" "shop-test-helper")
                   :pathname "tests/"
-                  :components ((:file "warns-check")
-                               (:file "at-package" :depends-on ("warns-check"))
+                  :components ((:file "at-package")
                                (:file "shop-internal-test-suite")
                                (:file "arity-tests" :depends-on ("at-package" "shop-internal-test-suite"))
                                (:module "umt-domain"

--- a/shop3/tests/io-tests.lisp
+++ b/shop3/tests/io-tests.lisp
@@ -191,227 +191,235 @@
              (gethash lookup-key (shop::domain-name-to-method-table domain))
              (shop::domain-method-to-name-table domain))))))))
 
-(test check-operator-definitions
-  ;; FIXME: it's possibly wrong to be depending on the accidental return of the operator object
-  (let ((op (with-fixture op-def-domain ()
-              (shop2::parse-domain-item domain :operator '(:operator (!!delete-truck ?truck)
-                                                           ()
-                                                           ((typevp ?truck truck))
-                                                           ())))))
-    (is (equal (shop2::operator-head op) '(!!delete-truck ?truck)))
-    (is (null (shop2::operator-preconditions op)))
-    (is (null (shop2::operator-additions op)))
-    (is (equal (shop2::operator-deletions op) '((typevp ?truck truck))))
-    (is (= (shop2::operator-cost-fun op) 1.0)))
-  (let ((op (with-fixture op-def-domain ()
-              (shop2::parse-domain-item domain :op '(:op (!!delete-truck ?truck)
-                                                           :delete
-                                                           ((typevp ?truck truck)))))))
-    (is (equal (shop2::operator-head op) '(!!delete-truck ?truck)))
-    (is (null (shop2::operator-preconditions op)))
-    (is (null (shop2::operator-additions op)))
-    (is (equal (shop2::operator-deletions op) '((typevp ?truck truck))))
-    (is (= (shop2::operator-cost-fun op) 1.0)))
+(fiveam:def-suite* check-operator-definitions :in io-tests)
+
+(test test-legacy-op-syntax
+ (let ((op (with-fixture op-def-domain ()
+             (shop::parse-domain-item domain :operator '(:operator (!!delete-truck ?truck)
+                                                         ()
+                                                         ((typevp ?truck truck))
+                                                         ())))))
+   (is (equal (shop::operator-head op) '(!!delete-truck ?truck)))
+   (is (null (shop::operator-preconditions op)))
+   (is (null (shop::operator-additions op)))
+   (is (equal (shop::operator-deletions op) '((typevp ?truck truck))))
+   (is (= (shop::operator-cost-fun op) 1.0))))
+
+(test new-op-syntax
+ (let ((op (with-fixture op-def-domain ()
+             (shop::parse-domain-item domain :op '(:op (!!delete-truck ?truck)
+                                                   :delete
+                                                   ((typevp ?truck truck)))))))
+   (is (equal (shop::operator-head op) '(!!delete-truck ?truck)))
+   (is (null (shop::operator-preconditions op)))
+   (is (null (shop::operator-additions op)))
+   (is (equal (shop::operator-deletions op) '((typevp ?truck truck))))
+   (is (= (shop::operator-cost-fun op) 1.0))))
   ;; here's a big one
-  (let ((op (with-fixture op-def-domain ()
-              (shop2::parse-domain-item domain :operator
-                                        '(:operator (!takeoff ?p ?flight-alt ?earliest-start ?start ?end)
-                                          ;; preconditions
-                                          (
-                                           (at ?p (pos ?north ?east ?alt)) ; a/c starts at alt == 0
-                                           (= 0 ?alt)
-                                           (fuel ?p ?fuel)
-                                           (assign ?fuel-cost (takeoff-fuel-cost ?flight-alt))
-                                           (assign ?fuel-remaining (- ?fuel ?fuel-cost))
-                                           (call >= ?fuel-remaining 0)
-                                           ;; uninformed hack FIXME
-                                           (assign ?duration 10)
-                                           ;; timelines for at update
-                                           (write-time (at ?p) ?t-write-at)
-                                           (read-time (at ?p) ?t-read-at)
-                                           ;; timelines for fuel update
-                                           (write-time (fuel ?p) ?t-write-fuel)
-                                           (read-time (fuel ?p) ?t-read-fuel)
-                                           
-                                           (assign ?start (max ?earliest-start ?t-write-at ?t-read-at ?t-write-fuel ?t-read-fuel))
-                                           (assign ?end (+ ?start ?duration))
-                                           )
-                                          ;; deletes
-                                          (
-                                           ;; update fuel and position
-                                           (at ?p (pos ?north ?east ?alt))
-                                           (fuel ?p ?fuel)
-                                           ;; timelines for at update
-                                           (write-time (at ?p) ?t-write-at)
-                                           (read-time (at ?p) ?t-read-at)
-                                           ;; timelines for fuel update
-                                           (write-time (fuel ?p) ?t-write-fuel)
-                                           (read-time (fuel ?p) ?t-read-fuel)
-                                           )
-                                          
-                                          ;; adds
-                                          (
-                                           ;; update fuel and position
-                                           (at ?p (pos ?north ?east ?flight-alt))
-                                           (fuel ?p ?fuel-remaining)
-                                           ;; timelines for at update
-                                           (write-time (at ?p) ?end)
-                                           (read-time (at ?p) ?end)
-                                           ;; timelines for fuel update
-                                           (write-time (fuel ?p) ?end)
-                                           (read-time (fuel ?p) ?end)
-                                           )
-                                          ;; cost
-                                          0)))))
-    (is (equal (shop2::operator-head op) '(!takeoff ?p ?flight-alt ?earliest-start ?start ?end)))
-    (is (equal (shop2::operator-preconditions op)
-        '(
-                                           (at ?p (pos ?north ?east ?alt)) ; a/c starts at alt == 0
-                                           (= 0 ?alt)
-                                           (fuel ?p ?fuel)
-                                           (assign ?fuel-cost (takeoff-fuel-cost ?flight-alt))
-                                           (assign ?fuel-remaining (- ?fuel ?fuel-cost))
-                                           (call >= ?fuel-remaining 0)
-                                           ;; uninformed hack FIXME
-                                           (assign ?duration 10)
-                                           ;; timelines for at update
-                                           (write-time (at ?p) ?t-write-at)
-                                           (read-time (at ?p) ?t-read-at)
-                                           ;; timelines for fuel update
-                                           (write-time (fuel ?p) ?t-write-fuel)
-                                           (read-time (fuel ?p) ?t-read-fuel)
-                                           
-                                           (assign ?start (max ?earliest-start ?t-write-at ?t-read-at ?t-write-fuel ?t-read-fuel))
-                                           (assign ?end (+ ?start ?duration))
-                                           )))
-    (is (equal (shop2::operator-additions op)
-               '(
-                                           ;; update fuel and position
-                                           (at ?p (pos ?north ?east ?flight-alt))
-                                           (fuel ?p ?fuel-remaining)
-                                           ;; timelines for at update
-                                           (write-time (at ?p) ?end)
-                                           (read-time (at ?p) ?end)
-                                           ;; timelines for fuel update
-                                           (write-time (fuel ?p) ?end)
-                                           (read-time (fuel ?p) ?end)
-                                           )))
-    (is (equal (shop2::operator-deletions op)
-               '(
-                 ;; update fuel and position
-                 (at ?p (pos ?north ?east ?alt))
-                 (fuel ?p ?fuel)
-                 ;; timelines for at update
-                 (write-time (at ?p) ?t-write-at)
-                 (read-time (at ?p) ?t-read-at)
-                 ;; timelines for fuel update
-                 (write-time (fuel ?p) ?t-write-fuel)
-                 (read-time (fuel ?p) ?t-read-fuel)
-                 )))
-    (is (= (shop2::operator-cost-fun op) 0)))
-  (let ((op (with-fixture op-def-domain ()
-              (warns shop::implicit-conjunction-warning
-               (shop2::parse-domain-item domain :op
-                                         '(:op (!takeoff ?p ?flight-alt ?earliest-start ?start ?end)
-                                           :precond
-                                           (
-                                            (at ?p (pos ?north ?east ?alt)) ; a/c starts at alt == 0
-                                            (= 0 ?alt)
-                                            (fuel ?p ?fuel)
-                                            (assign ?fuel-cost (takeoff-fuel-cost ?flight-alt))
-                                            (assign ?fuel-remaining (- ?fuel ?fuel-cost))
-                                            (call >= ?fuel-remaining 0)
-                                            ;; uninformed hack FIXME
-                                            (assign ?duration 10)
-                                            ;; timelines for at update
-                                            (write-time (at ?p) ?t-write-at)
-                                            (read-time (at ?p) ?t-read-at)
-                                            ;; timelines for fuel update
-                                            (write-time (fuel ?p) ?t-write-fuel)
-                                            (read-time (fuel ?p) ?t-read-fuel)
-                                           
-                                            (assign ?start (max ?earliest-start ?t-write-at ?t-read-at ?t-write-fuel ?t-read-fuel))
-                                            (assign ?end (+ ?start ?duration))
-                                            )
-                                           :delete
-                                           (
-                                            ;; update fuel and position
-                                            (at ?p (pos ?north ?east ?alt))
-                                            (fuel ?p ?fuel)
-                                            ;; timelines for at update
-                                            (write-time (at ?p) ?t-write-at)
-                                            (read-time (at ?p) ?t-read-at)
-                                            ;; timelines for fuel update
-                                            (write-time (fuel ?p) ?t-write-fuel)
-                                            (read-time (fuel ?p) ?t-read-fuel)
-                                            )
-                                          
-                                           :add
-                                           (
-                                            ;; update fuel and position
-                                            (at ?p (pos ?north ?east ?flight-alt))
-                                            (fuel ?p ?fuel-remaining)
-                                            ;; timelines for at update
-                                            (write-time (at ?p) ?end)
-                                            (read-time (at ?p) ?end)
-                                            ;; timelines for fuel update
-                                            (write-time (fuel ?p) ?end)
-                                            (read-time (fuel ?p) ?end)
-                                            )
-                                           :cost
-                                           0))))))
-    (is (equal (shop2::operator-head op) '(!takeoff ?p ?flight-alt ?earliest-start ?start ?end)))
-    (is (equal (shop2::operator-preconditions op)
-               '(and
-                 (at ?p (pos ?north ?east ?alt)) ; a/c starts at alt == 0
-                 (= 0 ?alt)
-                 (fuel ?p ?fuel)
-                 (assign ?fuel-cost (takeoff-fuel-cost ?flight-alt))
-                 (assign ?fuel-remaining (- ?fuel ?fuel-cost))
-                 (call >= ?fuel-remaining 0)
-                 ;; uninformed hack FIXME
-                 (assign ?duration 10)
-                 ;; timelines for at update
-                 (write-time (at ?p) ?t-write-at)
-                 (read-time (at ?p) ?t-read-at)
-                 ;; timelines for fuel update
-                 (write-time (fuel ?p) ?t-write-fuel)
-                 (read-time (fuel ?p) ?t-read-fuel)
-                 (assign ?start (max ?earliest-start ?t-write-at ?t-read-at ?t-write-fuel ?t-read-fuel))
-                 (assign ?end (+ ?start ?duration))
-                 )))
-    (is (equal (shop2::operator-additions op)
-               '(
-                 ;; update fuel and position
-                 (at ?p (pos ?north ?east ?flight-alt))
-                 (fuel ?p ?fuel-remaining)
-                 ;; timelines for at update
-                 (write-time (at ?p) ?end)
-                 (read-time (at ?p) ?end)
-                 ;; timelines for fuel update
-                 (write-time (fuel ?p) ?end)
-                 (read-time (fuel ?p) ?end)
-                 )))
-    (is (equal (shop2::operator-deletions op)
-               '(
-                 ;; update fuel and position
-                 (at ?p (pos ?north ?east ?alt))
-                 (fuel ?p ?fuel)
-                 ;; timelines for at update
-                 (write-time (at ?p) ?t-write-at)
-                 (read-time (at ?p) ?t-read-at)
-                 ;; timelines for fuel update
-                 (write-time (fuel ?p) ?t-write-fuel)
-                 (read-time (fuel ?p) ?t-read-fuel)
-                 )))
-    (is (= (shop2::operator-cost-fun op) 0))))
+
+(test complex-op-definition
+ (let ((op (with-fixture op-def-domain ()
+             (shop::parse-domain-item domain :operator
+                                      '(:operator (!takeoff ?p ?flight-alt ?earliest-start ?start ?end)
+                                        ;; preconditions
+                                        (
+                                         (at ?p (pos ?north ?east ?alt)) ; a/c starts at alt == 0
+                                         (= 0 ?alt)
+                                         (fuel ?p ?fuel)
+                                         (assign ?fuel-cost (takeoff-fuel-cost ?flight-alt))
+                                         (assign ?fuel-remaining (- ?fuel ?fuel-cost))
+                                         (call >= ?fuel-remaining 0)
+                                         ;; uninformed hack FIXME
+                                         (assign ?duration 10)
+                                         ;; timelines for at update
+                                         (write-time (at ?p) ?t-write-at)
+                                         (read-time (at ?p) ?t-read-at)
+                                         ;; timelines for fuel update
+                                         (write-time (fuel ?p) ?t-write-fuel)
+                                         (read-time (fuel ?p) ?t-read-fuel)
+                                        
+                                         (assign ?start (max ?earliest-start ?t-write-at ?t-read-at ?t-write-fuel ?t-read-fuel))
+                                         (assign ?end (+ ?start ?duration))
+                                         )
+                                        ;; deletes
+                                        (
+                                         ;; update fuel and position
+                                         (at ?p (pos ?north ?east ?alt))
+                                         (fuel ?p ?fuel)
+                                         ;; timelines for at update
+                                         (write-time (at ?p) ?t-write-at)
+                                         (read-time (at ?p) ?t-read-at)
+                                         ;; timelines for fuel update
+                                         (write-time (fuel ?p) ?t-write-fuel)
+                                         (read-time (fuel ?p) ?t-read-fuel)
+                                         )
+                                       
+                                        ;; adds
+                                        (
+                                         ;; update fuel and position
+                                         (at ?p (pos ?north ?east ?flight-alt))
+                                         (fuel ?p ?fuel-remaining)
+                                         ;; timelines for at update
+                                         (write-time (at ?p) ?end)
+                                         (read-time (at ?p) ?end)
+                                         ;; timelines for fuel update
+                                         (write-time (fuel ?p) ?end)
+                                         (read-time (fuel ?p) ?end)
+                                         )
+                                        ;; cost
+                                        0)))))
+   (is (equal (shop::operator-head op) '(!takeoff ?p ?flight-alt ?earliest-start ?start ?end)))
+   (is (equal (shop::operator-preconditions op)
+              '(
+                (at ?p (pos ?north ?east ?alt)) ; a/c starts at alt == 0
+                (= 0 ?alt)
+                (fuel ?p ?fuel)
+                (assign ?fuel-cost (takeoff-fuel-cost ?flight-alt))
+                (assign ?fuel-remaining (- ?fuel ?fuel-cost))
+                (call >= ?fuel-remaining 0)
+                ;; uninformed hack FIXME
+                (assign ?duration 10)
+                ;; timelines for at update
+                (write-time (at ?p) ?t-write-at)
+                (read-time (at ?p) ?t-read-at)
+                ;; timelines for fuel update
+                (write-time (fuel ?p) ?t-write-fuel)
+                (read-time (fuel ?p) ?t-read-fuel)
+               
+                (assign ?start (max ?earliest-start ?t-write-at ?t-read-at ?t-write-fuel ?t-read-fuel))
+                (assign ?end (+ ?start ?duration))
+                )))
+   (is (equal (shop::operator-additions op)
+              '(
+                ;; update fuel and position
+                (at ?p (pos ?north ?east ?flight-alt))
+                (fuel ?p ?fuel-remaining)
+                ;; timelines for at update
+                (write-time (at ?p) ?end)
+                (read-time (at ?p) ?end)
+                ;; timelines for fuel update
+                (write-time (fuel ?p) ?end)
+                (read-time (fuel ?p) ?end)
+                )))
+   (is (equal (shop::operator-deletions op)
+              '(
+                ;; update fuel and position
+                (at ?p (pos ?north ?east ?alt))
+                (fuel ?p ?fuel)
+                ;; timelines for at update
+                (write-time (at ?p) ?t-write-at)
+                (read-time (at ?p) ?t-read-at)
+                ;; timelines for fuel update
+                (write-time (fuel ?p) ?t-write-fuel)
+                (read-time (fuel ?p) ?t-read-fuel)
+                )))
+   (is (= (shop::operator-cost-fun op) 0))))
+
+(test implicit-conjunction-warning
+      (let ((op (with-fixture op-def-domain ()
+                  (warns shop::implicit-conjunction-warning
+                         (shop::parse-domain-item domain :op
+                                                  '(:op (!takeoff ?p ?flight-alt ?earliest-start ?start ?end)
+                                                    :precond
+                                                    (
+                                                     (at ?p (pos ?north ?east ?alt)) ; a/c starts at alt == 0
+                                                     (= 0 ?alt)
+                                                     (fuel ?p ?fuel)
+                                                     (assign ?fuel-cost (takeoff-fuel-cost ?flight-alt))
+                                                     (assign ?fuel-remaining (- ?fuel ?fuel-cost))
+                                                     (call >= ?fuel-remaining 0)
+                                                     ;; uninformed hack FIXME
+                                                     (assign ?duration 10)
+                                                     ;; timelines for at update
+                                                     (write-time (at ?p) ?t-write-at)
+                                                     (read-time (at ?p) ?t-read-at)
+                                                     ;; timelines for fuel update
+                                                     (write-time (fuel ?p) ?t-write-fuel)
+                                                     (read-time (fuel ?p) ?t-read-fuel)
+                                                     
+                                                     (assign ?start (max ?earliest-start ?t-write-at ?t-read-at ?t-write-fuel ?t-read-fuel))
+                                                     (assign ?end (+ ?start ?duration))
+                                                     )
+                                                    :delete
+                                                    (
+                                                     ;; update fuel and position
+                                                     (at ?p (pos ?north ?east ?alt))
+                                                     (fuel ?p ?fuel)
+                                                     ;; timelines for at update
+                                                     (write-time (at ?p) ?t-write-at)
+                                                     (read-time (at ?p) ?t-read-at)
+                                                     ;; timelines for fuel update
+                                                     (write-time (fuel ?p) ?t-write-fuel)
+                                                     (read-time (fuel ?p) ?t-read-fuel)
+                                                     )
+                                                    
+                                                    :add
+                                                    (
+                                                     ;; update fuel and position
+                                                     (at ?p (pos ?north ?east ?flight-alt))
+                                                     (fuel ?p ?fuel-remaining)
+                                                     ;; timelines for at update
+                                                     (write-time (at ?p) ?end)
+                                                     (read-time (at ?p) ?end)
+                                                     ;; timelines for fuel update
+                                                     (write-time (fuel ?p) ?end)
+                                                     (read-time (fuel ?p) ?end)
+                                                     )
+                                                    :cost
+                                                    0))))))
+
+        (is (equal (shop::operator-head op) '(!takeoff ?p ?flight-alt ?earliest-start ?start ?end)))
+        (is (equal (shop::operator-preconditions op)
+                   '(and
+                     (at ?p (pos ?north ?east ?alt)) ; a/c starts at alt == 0
+                     (= 0 ?alt)
+                     (fuel ?p ?fuel)
+                     (assign ?fuel-cost (takeoff-fuel-cost ?flight-alt))
+                     (assign ?fuel-remaining (- ?fuel ?fuel-cost))
+                     (call >= ?fuel-remaining 0)
+                     ;; uninformed hack FIXME
+                     (assign ?duration 10)
+                     ;; timelines for at update
+                     (write-time (at ?p) ?t-write-at)
+                     (read-time (at ?p) ?t-read-at)
+                     ;; timelines for fuel update
+                     (write-time (fuel ?p) ?t-write-fuel)
+                     (read-time (fuel ?p) ?t-read-fuel)
+                     (assign ?start (max ?earliest-start ?t-write-at ?t-read-at ?t-write-fuel ?t-read-fuel))
+                     (assign ?end (+ ?start ?duration))
+                     )))
+        (is (equal (shop::operator-additions op)
+                   '(
+                     ;; update fuel and position
+                     (at ?p (pos ?north ?east ?flight-alt))
+                     (fuel ?p ?fuel-remaining)
+                     ;; timelines for at update
+                     (write-time (at ?p) ?end)
+                     (read-time (at ?p) ?end)
+                     ;; timelines for fuel update
+                     (write-time (fuel ?p) ?end)
+                     (read-time (fuel ?p) ?end)
+                     )))
+        (is (equal (shop::operator-deletions op)
+                   '(
+                     ;; update fuel and position
+                     (at ?p (pos ?north ?east ?alt))
+                     (fuel ?p ?fuel)
+                     ;; timelines for at update
+                     (write-time (at ?p) ?t-write-at)
+                     (read-time (at ?p) ?t-read-at)
+                     ;; timelines for fuel update
+                     (write-time (fuel ?p) ?t-write-fuel)
+                     (read-time (fuel ?p) ?t-read-fuel)
+                     )))
+        (is (= (shop::operator-cost-fun op) 0))))
 
 ;;; domain definition fixture to test checks for repeated method names
 (def-fixture method-name-domain-fix (unique-method-names)
   (unwind-protect
    (progn
      (let ((*define-silently* t)
-           (shop2::*ignore-singleton-variables* t))
+           (shop::*ignore-singleton-variables* t))
        (eval
         `(defdomain (non-unique-method-domain :redefine-ok t :unique-method-names ,unique-method-names)
              (

--- a/shop3/tests/warns-check.lisp
+++ b/shop3/tests/warns-check.lisp
@@ -1,5 +1,9 @@
 (in-package :fiveam)
 
+(eval-when (:compile-toplevel :load-toplevel :execute)
+    (when (fboundp (uiop:intern* '#:warns :fiveam)) (pushnew :fiveam-warns *features*)))
+
+#+(not fiveam-warns)
 (defmacro warns (condition-spec
                  &body body)
   "Generates a pass if BODY signals a warning of type


### PR DESCRIPTION
By moving warns-check.lisp into the shop-test-helper component, then adding a depends-on to shop-pddl-tests for that module. The other component which was depending on the warns-check, shop-internal-tests, already depends on the shop-test-helper component.

Addresses #138 