### PR TITLE
Fix submodule checkout.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 
-name: CI
+name: test
 
 # Controls when the action will run.
 on:
@@ -56,11 +56,8 @@ jobs:
         apt-get install -y cmake make g++ flex bison
 
     - uses: actions/checkout@v3
-
-    - name: Checkout submodules
-      shell: bash
-      run: |
-        git submodule update --init --recursive
+      with:
+        submodules: true
 
     - name: cache validate
       id: cache-validate


### PR DESCRIPTION
Do *not* recursively checkout git submodules.

Use the "checkout" action to handle the git submodules instead of having an additional stanza in the workflow.