### PR TITLE
Fix package bug breaking buildapp build.

### DIFF
--- a/shop3/pddl/fluents.lisp
+++ b/shop3/pddl/fluents.lisp
@@ -28,6 +28,7 @@
   (:nicknames #:shop3.pddl-fluents)
   (:use common-lisp)
   (:import-from #:shop.theorem-prover
+                #:fluent-functions
                 #:fluents-mixin
                 #:+numerical-comparisons+
                 #:+binary-numerical-operators+

--- a/shop3/pddl/fluents.lisp
+++ b/shop3/pddl/fluents.lisp
@@ -1,21 +1,21 @@
 ;;;
 ;;; Version: MPL 1.1/LGPL 2.1
-;;; 
+;;;
 ;;; The contents of this file are subject to the Mozilla Public License
 ;;; Version 1.1 (the "License"); you may not use this file except in
 ;;; compliance with the License. You may obtain a copy of the License at
 ;;; http://www.mozilla.org/MPL/
-;;; 
+;;;
 ;;; Software distributed under the License is distributed on an "AS IS"
 ;;; basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
 ;;; License for the specific language governing rights and limitations under
 ;;; the License.
-;;; 
+;;;
 ;;; Alternatively, the contents of this file may be used under the terms of
 ;;; the GNU Lesser General Public License Version 2.1 or later (the
 ;;; "LGPL"), in which case the provisions of the LGPL are
-;;; applicable instead of those above. 
-;;; 
+;;; applicable instead of those above.
+;;;
 ;;; Copyright (C) 2020, Robert P. Goldman and SIFT, LLC.
 
 ;;;---------------------------------------------------------------------------
@@ -24,8 +24,20 @@
 ;;; import them into the SHOP package proper.
 ;;;---------------------------------------------------------------------------
 
+(defpackage :shop.pddl-fluents
+  (:nicknames #:shop3.pddl-fluents)
+  (:use common-lisp)
+  (:import-from #:shop.theorem-prover
+                #:fluents-mixin
+                #:+numerical-comparisons+
+                #:+binary-numerical-operators+
+                #:fluent-value
+                #:fluent-function-p
+                #:fluent-expr-p
+                #:fluent-comparison-p
+                #:f-exp-value))
 
-(in-package :shop3.theorem-prover)
+(in-package :shop3.pddl-fluents)
 
 (defparameter +numerical-comparisons+
   '(< > <= >= =)

--- a/shop3/pddl/prover.lisp
+++ b/shop3/pddl/prover.lisp
@@ -1,18 +1,18 @@
 ;;;
 ;;; Version: MPL 1.1/GPL 2.0/LGPL 2.1
-;;; 
+;;;
 ;;; The contents of this file are subject to the Mozilla Public License
 ;;; Version 1.1 (the "License"); you may not use this file except in
 ;;; compliance with the License. You may obtain a copy of the License at
 ;;; http://www.mozilla.org/MPL/
-;;; 
+;;;
 ;;; Software distributed under the License is distributed on an "AS IS"
 ;;; basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
 ;;; License for the specific language governing rights and limitations under
 ;;; the License.
-;;; 
-;;; The Original Code is SHOP2.  
-;;; 
+;;;
+;;; The Original Code is SHOP2.
+;;;
 ;;; The Initial Developer of the Original Code is the University of
 ;;; Maryland. Portions created by the Initial Developer are Copyright (C)
 ;;; 2002,2003 the Initial Developer. All Rights Reserved.
@@ -21,8 +21,8 @@
 ;;; Portions created by Drs. Goldman and Kuter are Copyright (C)
 ;;; 2017 SIFT, LLC.  These additions and modifications are also
 ;;; available under the MPL/GPL/LGPL licensing terms.
-;;; 
-;;; 
+;;;
+;;;
 ;;; Alternatively, the contents of this file may be used under the terms of
 ;;; either of the GNU General Public License Version 2 or later (the "GPL"),
 ;;; or the GNU Lesser General Public License Version 2.1 or later (the
@@ -38,16 +38,16 @@
 ;;; ----------------------------------------------------------------------
 ;;; FIXME: this GPR statement is wrong.
 ;;; Smart Information Flow Technologies Copyright 2006-2007 Unpublished work
-;;; 
+;;;
 ;;; GOVERNMENT PURPOSE RIGHTS
-;;; 
-;;; Contract No.         FA8650-06-C-7606, 
+;;;
+;;; Contract No.         FA8650-06-C-7606,
 ;;; Contractor Name      Smart Information Flow Technologies, LLC
 ;;;                      d/b/a SIFT, LLC
 ;;; Contractor Address   211 N 1st Street, Suite 300
 ;;;                      Minneapolis, MN 55401
 ;;; Expiration Date      5/2/2011
-;;; 
+;;;
 ;;; The Government's rights to use, modify, reproduce, release,
 ;;; perform, display, or disclose this software are restricted by
 ;;; paragraph (b)(2) of the Rights in Noncommercial Computer Software
@@ -113,7 +113,7 @@
         ;; there should be no free variables bound here -- actually, because of the syntax of PDDL methods, this may not be true....
         ;; (assert (equal new-answers '(nil)))
         (when *record-dependencies-p*
-          (setf depends 
+          (setf depends
                 (rd-union (first new-depends) depends)))))
     (seek-satisfiers other-goals state bindings newlevel just1 :domain domain
                                                                :dependencies (when *record-dependencies-p* (rd-union depends dependencies-in)))))

--- a/shop3/theorem-prover/package-thpr.lisp
+++ b/shop3/theorem-prover/package-thpr.lisp
@@ -63,15 +63,17 @@
     (:use :common-lisp :shop3.common :shop3.unifier :iterate)
     (:import-from #:shop3.common #:add-atom-to-state #:state-atoms #:domain-core)
     ;; make these symbols available for import
+    ;; to pddl/fluents.lisp (package shop.pddl-fluents)
     (:intern
-                #:fluents-mixin
-                #:+numerical-comparisons+
-                #:+binary-numerical-operators+
-                #:fluent-value
-                #:fluent-function-p
-                #:fluent-expr-p
-                #:fluent-comparison-p
-                #:f-exp-value)
+     #:fluents-mixin
+     #:fluent-functions
+     #:+numerical-comparisons+
+     #:+binary-numerical-operators+
+     #:fluent-value
+     #:fluent-function-p
+     #:fluent-expr-p
+     #:fluent-comparison-p
+     #:f-exp-value)
     (:export #:trace-print
              #:*shop-trace* #:*shop-trace-stream* #:*trace-query*
              #:*state*

--- a/shop3/theorem-prover/package-thpr.lisp
+++ b/shop3/theorem-prover/package-thpr.lisp
@@ -63,13 +63,15 @@
     (:use :common-lisp :shop3.common :shop3.unifier :iterate)
     (:import-from #:shop3.common #:add-atom-to-state #:state-atoms #:domain-core)
     ;; make these symbols available for import
-    (:intern  #:+numerical-comparisons+
-              #:fluent-value
-              #:f-exp-value
-                  #:fluents-mixin
-                  #:fluent-function-p
-                  #:fluent-expr-p
-                  #:fluent-comparison-p)
+    (:intern
+                #:fluents-mixin
+                #:+numerical-comparisons+
+                #:+binary-numerical-operators+
+                #:fluent-value
+                #:fluent-function-p
+                #:fluent-expr-p
+                #:fluent-comparison-p
+                #:f-exp-value)
     (:export #:trace-print
              #:*shop-trace* #:*shop-trace-stream* #:*trace-query*
              #:*state*


### PR DESCRIPTION
The symbols for PDDL fluents were not properly getting initialized, causing the buildapp build on CCL to fail.