### PR TITLE
Add BUILDAPP variable to the buildapp-script.

### DIFF
--- a/shop3/buildapp/buildapp-script
+++ b/shop3/buildapp/buildapp-script
@@ -3,11 +3,12 @@
 ASDF_DIR=${ASDF_DIR:-${HOME}/lisp/asdf/build}
 THIS_DIR=$(realpath $(dirname ${BASH_SOURCE}))
 QUICKLISP_DIR=${QUICKLISP_DIR:-~/quicklisp}
+BUILDAPP=${BUILDAPP:-buildapp}
 
-# --dispatched-entry "shop/shop-app::main" \
-# --dispatched-entry "ess-shop/shop-app::ess-main" \
-#          --entry "shop-app::main" \
-buildapp --logfile "/tmp/buildapp-shop-app.log" \
+# --DISPATCHED-ENTRY "SHOP/SHOP-APP::MAIN" \
+# --DISPATCHED-ENTRY "ESS-SHOP/SHOP-APP::ESS-MAIN" \
+#          --ENTRY "SHOP-APP::MAIN" \
+${BUILDAPP} --logfile "/tmp/buildapp-shop-app.log" \
          --output shop-app \
          --dispatched-entry "/shop-app::main" \
          --dispatched-entry "shop/shop-app::classic-main" \


### PR DESCRIPTION
This enables us to be able to make buildapp binaries for both CCL and SBCL.  Currently, the buildapp binary is either based on CCL or SBCL, but can't make binaries for both, so we need to install a CCL buildapp and an SBCL buildapp if we want to build both on the same system, and in this case need a mechanism for choosing which to use.