### PR TITLE
Some tweaks to debugging.lisp, towards making more tracing work

### DIFF
--- a/shop3/io/debugging.lisp
+++ b/shop3/io/debugging.lisp
@@ -62,14 +62,13 @@
 (defvar *start-run-time*)
 (defvar *start-real-time*)
 
-;; (defvar *traced-operators* nil)      ; break when attempting to
+(defvar *traced-operators* nil)      ; break when attempting to
                                         ; apply one of these.
 (defvar *traced-methods* nil)           ; break when attempting to
                                         ; apply one of these.
 (defvar *traced-tasks* nil)             ; break when attempting to
                                         ; expand one of these.
-(defvar *traced-axioms*
-  nil)
+(defvar *traced-axioms* nil)
 (defvar *traced-goals* nil)
 
 
@@ -123,6 +122,7 @@ currently being traced.
                (case (car item)
                  (:task (trace-item *traced-tasks*))
                  (:method (trace-item *traced-methods*))
+		 (:operator (trace-item *traced-operators*))
                  (:goal (trace-item *traced-goals*))
                  (:axiom (trace-item *traced-axioms*))
                  (otherwise
@@ -154,6 +154,9 @@ currently being traced.
    (mapcar #'(lambda (methname)
                `(:method ,methname))
            *traced-methods*)
+   (mapcar #'(lambda (opname)
+               `(:operator ,opname))
+           *traced-operators*)
    (mapcar #'(lambda (goalname)
                `(:goal ,goalname))
            *traced-goals*)
@@ -171,7 +174,7 @@ currently being traced.
 (defun shop-untrace-all ()
   (setf *shop-trace* nil
        *traced-tasks* nil
-       ;;*traced-operators* nil
+       *traced-operators* nil
        *traced-methods* nil
        *traced-goals* nil
        *traced-axioms* nil))


### PR DESCRIPTION
1. Behavior of master:

a) Global tracing of :methods, :tasks, :operators, :axioms works fine. b) (shop-trace (:method <method name>)) also works, but needs what in the manual is denoted [nm] or [n1], [n2] etc. This could be made clearer in the manual.
   (shop-trace (:operator <op name>)) results in an error.
   (shop-trace (:task <task name>)) works, causes a break.
   (shop-trace (:axiom <axiom name>)) doesn't do anything.

2. Behavior of this branch/pull:
now (shop-trace (:operator <op name>)) is accepted, but no tracing happens.

3. I see that planning-engine/task-reductions.lisp has to be modified now to handle operators and axioms.