### PR TITLE
Add rudimentary support for PDDL :constants.

### DIFF
--- a/shop3/io/input.lisp
+++ b/shop3/io/input.lisp
@@ -167,7 +167,7 @@ variable *PROBLEM*."
           (setf *problem* problem-name)
           #+allegro
           (let ((excl:*redefinition-warnings* (not redefine-ok)))
-           (excl:record-source-file problem-name :type :shop3-problem))
+            (excl:record-source-file problem-name :type :shop3-problem))
           problem-inst)))))
 
 (defmethod initialize-problem ((problem problem) &key state tasks)

--- a/shop3/package.lisp
+++ b/shop3/package.lisp
@@ -250,6 +250,7 @@
              #:adl-mixin
              #:adl-domain
              #:fluents-mixin
+             #:pddl-fluents-domain
 
 
              ;; MIXIN

--- a/shop3/pddl/pddl.lisp
+++ b/shop3/pddl/pddl.lisp
@@ -921,6 +921,10 @@ set of dependencies."
       (parse-pddl-method domain method)
     (index-method-on-domain domain method-id method-obj)))
 
+;;; FIXME: for now ignore the :constants property in PDDL domains
+(defmethod parse-domain-item ((domain simple-pddl-domain) (item-key (eql :constants)) constant-list)
+  (values))
+
 (defun parse-pddl-method (domain method)
   (let* ((method (uniquify-anonymous-variables method))
          (method-head (second method))

--- a/shop3/pddl/pddl.lisp
+++ b/shop3/pddl/pddl.lisp
@@ -37,7 +37,7 @@
 ;;; or the LGPL.
 ;;; ----------------------------------------------------------------------
 
-;;; Smart Information Flow Technologies Copyright 2006-2007 Unpublished work
+;;; Smart Information Flow Technologies Copyright 2006-2025 Unpublished work
 ;;;
 ;;; GOVERNMENT PURPOSE RIGHTS
 ;;;
@@ -143,9 +143,17 @@ absolute pathname, or a path-relative namestring)."
   ((source-pddl-domain
     :initarg :source-pddl-domain
     :reader source-pddl-domain
+    )
+   (constant-defs
+    :initarg :constant-defs
+    :reader constant-defs
+    :documentation "An ALIST of constant . type elements read from the
+:constants property of a PDDL domain definition. If this is not a
+typing domain, then this will simply be a list of symbols."
     ))
   (:documentation "A new class of SHOP3 domain that permits inclusion of
 PDDL operator definitions.")
+  (:default-initargs :constant-defs nil)
   )
 
 (defgeneric pddl-method-p (domain sexpr)
@@ -219,6 +227,9 @@ PDDL operator definitions.")
 PDDL operator definitions.  Right now, this approximates what happens if you have
 the :adl flag in a PDDL domain file.")
   )
+
+(defclass metric-pddl-domain (fluents-mixin pddl-domain)
+  ())
 
 (defclass adl-domain (simple-pddl-domain adl-mixin)
   ())
@@ -921,8 +932,18 @@ set of dependencies."
       (parse-pddl-method domain method)
     (index-method-on-domain domain method-id method-obj)))
 
-;;; FIXME: for now ignore the :constants property in PDDL domains
+;;; Store the constants on the DOMAIN so that they can later be added to the problem's state
+;;; this is a no-op except for typed domains.
 (defmethod parse-domain-item ((domain simple-pddl-domain) (item-key (eql :constants)) constant-list)
+  (if (typep domain 'pddl-typing-mixin)
+      ;; if this is not a typed domain, then there's no impact of adding a constant which
+      ;; is not mentioned in any facts
+      (multiple-value-bind (vars types)
+          (parse-typed-list (rest constant-list))
+        (setf (slot-value domain 'constant-defs)
+              (pairlis vars types)))
+      (setf (slot-value domain 'constant-defs)
+            (rest constant-list)))
   (values))
 
 (defun parse-pddl-method (domain method)
@@ -1012,3 +1033,17 @@ new facts of the form (fluent-value fluent-function value)."
                                (fluent-function-p domain (first (second atom))))
                           (collecting `(fluent-value ,(second atom) ,(third atom)))
                           (collecting atom)))))
+
+;;;---------------------------------------------------------------------------
+;;; Process problem initial state to add constants defined in the domain,
+;;; if any.
+;;;---------------------------------------------------------------------------
+(defmethod make-initial-state :around ((domain pddl-typing-mixin) state-encoding atoms &key)
+  "Take domain constant definitions and add corresponding `(<type> <var>)` to the set of
+atoms of the problem."
+  (let ((new-atoms
+          (alexandria:when-let (constant-defs (constant-defs domain))
+            (iter (for (var . type) in constant-defs)
+              (collecting `(,type ,var))))))
+    (call-next-method domain state-encoding
+                      (append new-atoms atoms))))

--- a/shop3/shop-version.lisp-expr
+++ b/shop3/shop-version.lisp-expr
@@ -1,4 +1,4 @@
-"3.13.0"
+"3.13.1" ; fix missing handling of :constants in PDDL domains.
 ; 3.11 introduces command-line applications and HDDL plan output
 ; 3.12 introduces the use of random-state for repeatability
 ; 3.13 introduces enhancements needed for the plan repair experiments

--- a/shop3/shop3.asd
+++ b/shop3/shop3.asd
@@ -254,7 +254,7 @@ minimal affected subtree."
 (defsystem shop3/test
     :defsystem-depends-on ((:version "fiveam-asdf" "2"))
     :class "fiveam-asdf:fiveam-tester-system"
-    :test-names ((pddl-tests . :shop3)  ; 144
+    :test-names ((pddl-tests . :shop3)  ; 145
                  (protection-test . :protection-test)  ; 16
                  ;; all the following are now subsumed into all-shop3-internal-tests
                  (test-sort-by . :arity-test) ; 7
@@ -281,7 +281,7 @@ minimal affected subtree."
                  (hddl-plan-tests . :shop-hddl-tests) ; 7
                  (new-plan-tree-tests . :new-plan-tree-tests) ; 22
                  )
-    :num-checks 1131
+    :num-checks 1132
     :depends-on ((:version "shop3" (:read-file-form "shop-version.lisp-expr"))
                  "shop3/openstacks"
                  "shop3/pddl-helpers"

--- a/shop3/tests/pddl-tests.lisp
+++ b/shop3/tests/pddl-tests.lisp
@@ -38,7 +38,7 @@
 ;;; MPL, the GPL or the LGPL.
 ;;; ---------------------------------------------------------------------
 
-;;; Smart Information Flow Technologies Copyright 2006-2007
+;;; Smart Information Flow Technologies Copyright 2006-2025
 ;;; Unpublished work
 ;;;
 ;;; GOVERNMENT PURPOSE RIGHTS
@@ -988,6 +988,20 @@
                                                       (problem-state (find-problem 'test-rover-problem))
                                                       :test 'equalp)
             :return-dependencies nil :domain *domain*))))
+
+(fiveam:test (pddl-domain-constant-defs :suite pddl-tests)
+  (let* ((pddl-domain-file (asdf-utilities:system-relative-pathname "shop3" "examples/UMT2/from-archive/UMT.pddl"))
+         (shop-domain (eval `(defdomain (test-umt-domain :type metric-pddl-domain)
+                              ((:include um-translog-2 ,pddl-domain-file)))))
+         (new-state (shop.common:make-initial-state shop-domain :mixed nil)))
+    (fiveam:is (alexandria:set-equal
+                '((vtype regularv) (vtype flatbed) (vtype tanker) (vtype hopper) (vtype auto) (vtype air)
+                  (vptype truck) (vptype airplane) (vptype train)
+                  (rtype road-route) (rtype rail-route) (rtype air-route)
+                  (ptype regularp) (ptype bulky) (ptype liquid) (ptype granular) (ptype cars) (ptype mail)
+                  (ltype airport) (ltype train-station))
+                (state-atoms new-state)
+                :test 'equalp))))
 
 
 (fiveam:def-suite rovers-tests :in pddl-tests)


### PR DESCRIPTION
This property of PDDL domain definitions was not previously supported by our PDDL parser.