### PR TITLE
Fix buggy prop-sorter

### DIFF
--- a/shop3/common/state-utils.lisp
+++ b/shop3/common/state-utils.lisp
@@ -1,18 +1,18 @@
 ;;;
 ;;; Version: MPL 1.1/GPL 2.0/LGPL 2.1
-;;; 
+;;;
 ;;; The contents of this file are subject to the Mozilla Public License
 ;;; Version 1.1 (the "License"); you may not use this file except in
 ;;; compliance with the License. You may obtain a copy of the License at
 ;;; http://www.mozilla.org/MPL/
-;;; 
+;;;
 ;;; Software distributed under the License is distributed on an "AS IS"
 ;;; basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
 ;;; License for the specific language governing rights and limitations under
 ;;; the License.
-;;; 
-;;; The Original Code is SHOP2.  
-;;; 
+;;;
+;;; The Original Code is SHOP2.
+;;;
 ;;; The Initial Developer of the Original Code is the University of
 ;;; Maryland. Portions created by the Initial Developer are Copyright (C)
 ;;; 2002,2003 the Initial Developer. All Rights Reserved.
@@ -21,8 +21,8 @@
 ;;; Portions created by Drs. Goldman and Maraist are Copyright (C)
 ;;; 2004-2007 SIFT, LLC.  These additions and modifications are also
 ;;; available under the MPL/GPL/LGPL licensing terms.
-;;; 
-;;; 
+;;;
+;;;
 ;;; Alternatively, the contents of this file may be used under the terms of
 ;;; either of the GNU General Public License Version 2 or later (the "GPL"),
 ;;; or the GNU Lesser General Public License Version 2.1 or later (the
@@ -38,16 +38,16 @@
 ;;; ----------------------------------------------------------------------
 
 ;;; Smart Information Flow Technologies Copyright 2006-2007 Unpublished work
-;;; 
+;;;
 ;;; GOVERNMENT PURPOSE RIGHTS
-;;; 
-;;; Contract No.         FA8650-06-C-7606, 
+;;;
+;;; Contract No.         FA8650-06-C-7606,
 ;;; Contractor Name      Smart Information Flow Technologies, LLC
 ;;;                      d/b/a SIFT, LLC
 ;;; Contractor Address   211 N 1st Street, Suite 300
 ;;;                      Minneapolis, MN 55401
 ;;; Expiration Date      5/2/2011
-;;; 
+;;;
 ;;; The Government's rights to use, modify, reproduce, release,
 ;;; perform, display, or disclose this software are restricted by
 ;;; paragraph (b)(2) of the Rights in Noncommercial Computer Software
@@ -116,7 +116,7 @@ using MAKE-INITIAL-STATE.")
   (rest (assoc pred (state-body st))))
 
 (defmethod state-candidate-atoms-for-goal ((st list-state) goal)
-  
+
   (state-all-atoms-for-predicate st (first goal)))
 
 (defmethod copy-state ((st list-state))
@@ -136,7 +136,7 @@ using MAKE-INITIAL-STATE.")
 ;;; I think this code is going to be pretty inefficient, since it's not properly tail-recursive.  I don't think it would be terribly difficult to replace this with a properly tail-recursive program.  Alternatively, a simple destructive update using (setf (getf statebody (car atom)) ....) might work, but I don't know whether a destructive version of this operation would be acceptable. [2008-02-06: rpg
 (defun LIST-insert-atom-into-statebody (atom statebody)
   ;; the statebody here is evidently implemented as an associative structure, indexed on the predicate, of cells whose cdr is a LIST of atoms
-  (cond 
+  (cond
    ((null statebody)
     (list (list (car atom) atom)))
    ((string< (car atom) (caar statebody))
@@ -255,7 +255,7 @@ using MAKE-INITIAL-STATE.")
 
 (defmethod state-atoms ((st mixed-state))
   (let ((statebody (state-body st)))
-    (let ((acc nil)) 
+    (let ((acc nil))
       (maphash #'(lambda (pred lis)
                    (setf acc
                          (append (mapcar #'(lambda (entry) (cons pred entry)) lis)
@@ -329,7 +329,7 @@ using MAKE-INITIAL-STATE.")
   (let* ((statebody (state-body st))
          (subtable (gethash (first atom) statebody)) ; hash-table
          (sub-key (if (> (length atom) 1)
-                      (second atom) 
+                      (second atom)
                       +SINGLETON-TERM+))
          (subtable-entry (when subtable
                            (gethash sub-key subtable)))) ; list
@@ -345,7 +345,7 @@ using MAKE-INITIAL-STATE.")
 
 (defmethod state-atoms ((st doubly-hashed-state))
   (let ((statebody (state-body st))     ; this is a hash-table of hash-tables
-        (acc nil)) 
+        (acc nil))
     (maphash #'(lambda (pred subtable)
                  (maphash #'(lambda (first-arg lis)
                               (if (eq first-arg +SINGLETON-TERM+)
@@ -478,7 +478,7 @@ using MAKE-INITIAL-STATE.")
                        acc)))
              (first (state-body st)))
     (remove-duplicates (append
-                        acc 
+                        acc
                         (mapcan #'(lambda (entry) (copy-list (cdr entry)))
                                 (fourth (state-body st)))))))
 
@@ -608,7 +608,7 @@ using MAKE-INITIAL-STATE.")
       nil))
    (t
     (incf (second (first position)))
-    (cond 
+    (cond
      ((< (second (first position)) (first pred-type-counts))
       position)
      ((null (rest position))
@@ -635,11 +635,11 @@ Shorter lists are considered smaller if one is a prefix of the other."
   (flet ((elem< (x y)
            "Compare two elements deterministically: numbers first, then symbols."
            (cond ((and (numberp x) (numberp y))         ; Compare numbers
-                  (< x y)) 
+                  (< x y))
                  ((numberp x) t)                        ; Numbers come before non-numbers
                  ((numberp y) nil)                      ; Non-numbers come after numbers
                  ((and (symbolp x) (symbolp y))         ; Compare symbols lexicographically
-                  (string-lessp (symbol-name x) (symbol-name y)))
+                  (string-lessp x y))
                  ((symbolp x) t)                        ; Symbols come before other types
                  ((symbolp y) nil)                      ; Other types come after symbols
                  (t nil))))                             ; Default: treat as equal

--- a/shop3/common/state-utils.lisp
+++ b/shop3/common/state-utils.lisp
@@ -631,10 +631,10 @@ using MAKE-INITIAL-STATE.")
 (defun prop-sorter (p1 p2)
   "Function that can be used inside CL:SORT to sort lists of symbols and
    numbers deterministically.  Compares lists element by element.
-Shorter lists are considered smaller if one is a prefix of the other."
+   Shorter lists are considered smaller if one is a prefix of the other."
   (flet ((elem< (x y)
            "Compare two elements deterministically: numbers first, then symbols."
-           (cond ((and (numberp x) (numberp y))         ; Compare numbers
+           (cond ((and (realp x) (realp y))         ; Compare real numbers
                   (cond ((< x y) t)
                         ((> x y) nil)
                         ;; integers before other types
@@ -643,18 +643,11 @@ Shorter lists are considered smaller if one is a prefix of the other."
                         ;; rationals before floats
                         ((rationalp x) t)
                         ((rationalp y) nil)
-                        ;; floats before complex
+                        ;; floats before other reals (if any such exist!)
                         ((floatp x) t)
-                        ((and (complexp x) (complexp y))
-                         ;; suggested by ChatGPT
-                         (or (< (realpart x) (realpart y))
-                             (and (= (realpart x) (realpart y))
-                                  (< (imagpart x) (imagpart y)))))
                         (t nil)))
-                 ((and (numberp x) (numberp y))         ; Compare numbers
-                  (< x y))
-                 ((numberp x) t)                        ; Numbers come before non-numbers
-                 ((numberp y) nil)                      ; Non-numbers come after numbers
+                 ((realp x) t)                        ; Real numbers come before non-numbers (and complex numbers)
+                 ((realp y) nil)                      ; Non-numbers come after real numbers
                  ((and (stringp x) (stringp y))
                   (string< x y))
                  ((and (symbolp x) (symbolp y)) ; Compare symbols lexicographically

--- a/shop3/common/state-utils.lisp
+++ b/shop3/common/state-utils.lisp
@@ -634,9 +634,12 @@ using MAKE-INITIAL-STATE.")
    Shorter lists are considered smaller if one is a prefix of the other."
   (flet ((elem< (x y)
            "Compare two elements deterministically: numbers first, then symbols."
-           (cond ((and (realp x) (realp y))         ; Compare real numbers
+           (cond ((and (realp x) (realp y))         ; Compare reals
                   (cond ((< x y) t)
                         ((> x y) nil)
+                        ;; x and y are numerically equal, distinguish types:
+                        ((eq (type-of x) (type-of y)) ;; same type, move to next element.
+                         nil)
                         ;; integers before other types
                         ((integerp x) t)
                         ((integerp y) nil)
@@ -645,9 +648,11 @@ using MAKE-INITIAL-STATE.")
                         ((rationalp y) nil)
                         ;; floats before other reals (if any such exist!)
                         ((floatp x) t)
+                        ((floatp y) nil)
                         (t nil)))
-                 ((realp x) t)                        ; Real numbers come before non-numbers (and complex numbers)
-                 ((realp y) nil)                      ; Non-numbers come after real numbers
+                 ;; reals before symbols, strings and other things, eg complex numbers, arrays, objects
+                 ((realp x) t)
+                 ((realp y) nil)
                  ((and (stringp x) (stringp y))
                   (string< x y))
                  ((and (symbolp x) (symbolp y)) ; Compare symbols lexicographically

--- a/shop3/common/state-utils.lisp
+++ b/shop3/common/state-utils.lisp
@@ -629,34 +629,27 @@ using MAKE-INITIAL-STATE.")
     H2))
 
 (defun prop-sorter (p1 p2)
-  "Function that can be used inside CL:SORT to sort SHOP literals alphabetically
-for easier human inspection."
-  (flet ((elem< (p1 p2)
-           (cond ((numberp p1)
-                  (if (numberp p2)
-                      (< p1 p2)
-                      t))
-                 ((numberp p2)          ;only p2 is a number
-                  nil)
-                 ((symbolp p1)
-                  (if (symbolp p2)
-                      (cond 
-                        ((string-lessp p1 p2) t)
-                        ((string-lessp p2 p1) (values nil t))
-                        (t (values nil nil)))
-                      ;; p1 is a symbol and p2 is something weird; put p2 first
-                      nil))
-                 ;; arbitrary
-                 (t t))))
-    (cond ((and p1 p2)
-           (multiple-value-bind (lessp known)
-               (elem< (first p1) (first p2))
-             (cond (lessp t)
-                   (known nil)
-                   (t
-                    (prop-sorter (rest p1) (rest p2))))))
-          (p1 nil)
-          (t t))))
+  "Function that can be used inside CL:SORT to sort lists of symbols and
+   numbers deterministically.  Compares lists element by element.
+Shorter lists are considered smaller if one is a prefix of the other."
+  (flet ((elem< (x y)
+           "Compare two elements deterministically: numbers first, then symbols."
+           (cond ((and (numberp x) (numberp y))         ; Compare numbers
+                  (< x y)) 
+                 ((numberp x) t)                        ; Numbers come before non-numbers
+                 ((numberp y) nil)                      ; Non-numbers come after numbers
+                 ((and (symbolp x) (symbolp y))         ; Compare symbols lexicographically
+                  (string-lessp (symbol-name x) (symbol-name y)))
+                 ((symbolp x) t)                        ; Symbols come before other types
+                 ((symbolp y) nil)                      ; Other types come after symbols
+                 (t nil))))                             ; Default: treat as equal
+    (iter (for e1 in p1)
+          (for e2 in p2)
+      (cond
+        ((elem< e1 e2) (return t))   ; p1 is less than p2
+        ((elem< e2 e1) (return nil))) ; p1 is greater than p2
+      (finally
+        (return (< (length p1) (length p2))))))) ; shorter list comes first
 
 (defmethod state-trajectory ((st tagged-state) &key sorted)
   (let ((state (copy-state st)))

--- a/shop3/common/state-utils.lisp
+++ b/shop3/common/state-utils.lisp
@@ -635,21 +635,41 @@ Shorter lists are considered smaller if one is a prefix of the other."
   (flet ((elem< (x y)
            "Compare two elements deterministically: numbers first, then symbols."
            (cond ((and (numberp x) (numberp y))         ; Compare numbers
+                  (cond ((< x y) t)
+                        ((> x y) nil)
+                        ;; integers before other types
+                        ((integerp x) t)
+                        ((integerp y) nil)
+                        ;; rationals before floats
+                        ((rationalp x) t)
+                        ((rationalp y) nil)
+                        ;; floats before complex
+                        ((floatp x) t)
+                        ((and (complexp x) (complexp y))
+                         ;; suggested by ChatGPT
+                         (or (< (realpart x) (realpart y))
+                             (and (= (realpart x) (realpart y))
+                                  (< (imagpart x) (imagpart y)))))
+                        (t nil)))
+                 ((and (numberp x) (numberp y))         ; Compare numbers
                   (< x y))
                  ((numberp x) t)                        ; Numbers come before non-numbers
                  ((numberp y) nil)                      ; Non-numbers come after numbers
-                 ((and (symbolp x) (symbolp y))         ; Compare symbols lexicographically
+                 ((and (stringp x) (stringp y))
+                  (string< x y))
+                 ((and (symbolp x) (symbolp y)) ; Compare symbols lexicographically
                   (string-lessp x y))
                  ((symbolp x) t)                        ; Symbols come before other types
                  ((symbolp y) nil)                      ; Other types come after symbols
-                 (t nil))))                             ; Default: treat as equal
+                 (t (string< (format nil "~S" x)
+                             (format nil "~S" y)))))) ; Default: take printrep and sort as string
     (iter (for e1 in p1)
-          (for e2 in p2)
+      (for e2 in p2)
       (cond
         ((elem< e1 e2) (return t))   ; p1 is less than p2
         ((elem< e2 e1) (return nil))) ; p1 is greater than p2
       (finally
-        (return (< (length p1) (length p2))))))) ; shorter list comes first
+       (return (< (length p1) (length p2))))))) ; shorter list comes first
 
 (defmethod state-trajectory ((st tagged-state) &key sorted)
   (let ((state (copy-state st)))

--- a/shop3/shop3.asd
+++ b/shop3/shop3.asd
@@ -278,7 +278,7 @@ minimal affected subtree."
                  (enhanced-plan-tree . :shop3-user) ; 2
                  (theorem-prover-tests . :shop-theorem-prover-tests)  ; 26
                  (test-plan-repair . :shop-replan-tests) ; 3
-                 (test-shop-states . :test-states) ; 112
+                 (test-shop-states . :test-states) ; 114
                  (analogical-replay-tests . :analogical-replay-tests) ; 24
                  (plan-tree-tests . :plan-tree-tests)  ; 40
                  (search-tests . :search-tests) ; 9
@@ -286,7 +286,7 @@ minimal affected subtree."
                  (hddl-plan-tests . :shop-hddl-tests) ; 7
                  (new-plan-tree-tests . :new-plan-tree-tests) ; 22
                  )
-    :num-checks 1164
+    :num-checks 1166
     :depends-on ((:version "shop3" (:read-file-form "shop-version.lisp-expr"))
                  "shop3/openstacks"
                  "shop3/pddl-helpers"

--- a/shop3/shop3.asd
+++ b/shop3/shop3.asd
@@ -278,7 +278,7 @@ minimal affected subtree."
                  (enhanced-plan-tree . :shop3-user) ; 2
                  (theorem-prover-tests . :shop-theorem-prover-tests)  ; 26
                  (test-plan-repair . :shop-replan-tests) ; 3
-                 (test-shop-states . :test-states) ; 110
+                 (test-shop-states . :test-states) ; 112
                  (analogical-replay-tests . :analogical-replay-tests) ; 24
                  (plan-tree-tests . :plan-tree-tests)  ; 40
                  (search-tests . :search-tests) ; 9
@@ -286,7 +286,7 @@ minimal affected subtree."
                  (hddl-plan-tests . :shop-hddl-tests) ; 7
                  (new-plan-tree-tests . :new-plan-tree-tests) ; 22
                  )
-    :num-checks 1162
+    :num-checks 1164
     :depends-on ((:version "shop3" (:read-file-form "shop-version.lisp-expr"))
                  "shop3/openstacks"
                  "shop3/pddl-helpers"

--- a/shop3/tests/state-tests.lisp
+++ b/shop3/tests/state-tests.lisp
@@ -161,7 +161,7 @@
                          (is (set-equal volume-load-facts candidates :test 'equalp)
                              "Getting facts for location 3 gives unexpected results ~s for encoding ~s" candidates encoding)))))))
 
-(def-suite* prop-sorter-suite)
+(def-suite* prop-sorter-suite :in test-shop-states)
 
 (test prop-sorter-test
   "Test that prop-sorter sorts propositions correctly."

--- a/shop3/tests/state-tests.lisp
+++ b/shop3/tests/state-tests.lisp
@@ -106,7 +106,7 @@
    (iter (for encoding in '(:list :hash :mixed :doubly-hashed :bit))
      (as state-type in state-types)
      (as state = (make-initial-state domain encoding facts))
-     (let ((new-state 
+     (let ((new-state
              (copy-state state)))
        (is-true (typep state state-type))
        (is-true (typep new-state state-type) "State of type ~a is copied to the wrong class: ~a" encoding (class-of new-state))
@@ -160,3 +160,15 @@
                              "Getting facts for location 3 gives unexpected results ~s for encoding ~s" candidates encoding)
                          (is (set-equal volume-load-facts candidates :test 'equalp)
                              "Getting facts for location 3 gives unexpected results ~s for encoding ~s" candidates encoding)))))))
+
+(def-suite* prop-sorter-suite)
+
+(test prop-sorter-test
+  "Test that prop-sorter sorts propositions correctly."
+  (is (equal '((1 2) (1 3) (1 4))
+             (sort (copy-list '((1 4) (1 2) (1 3))) 'prop-sorter))))
+
+(test prop-sorter-length-preference
+  "Test that shorter lists are sorted before longer lists when they share a prefix."
+  (is (equal '((1) (1 2) (1 2 3) (1 3))
+             (sort (copy-list '((1 2 3) (1) (1 3) (1 2))) 'prop-sorter))))

--- a/shop3/tests/state-tests.lisp
+++ b/shop3/tests/state-tests.lisp
@@ -172,3 +172,15 @@
   "Test that shorter lists are sorted before longer lists when they share a prefix."
   (is (equal '((1) (1 2) (1 2 3) (1 3))
              (sort (copy-list '((1 2 3) (1) (1 3) (1 2))) 'prop-sorter))))
+
+(test prop-sorter-type-mismatch
+  "Test that PROP-SORTER is deterministic even under conditions of type
+mismatch."
+  (is (equal (sort `((1 2 3) (1 #(0 1 2)) (1 A) (1 ,(make-array '(2 2)))) 'prop-sorter)
+             (sort `((1 2 3) (1 ,(make-array '(2 2))) (1 #(0 1 2)) (1 A)) 'prop-sorter))))
+
+(test prop-sorter-numerical-subtypes
+  "Test that PROP-SORTER handles equal numbers of unequal types."
+  (let ((sorted '((1 1/2) (1 0.5) (1 1) (1 1.0) (1 2) (1 2.0) (1 #C (2.0 0)))))
+    (is (equal sorted
+               (sort (reverse sorted) 'prop-sorter)))))

--- a/shop3/tests/state-tests.lisp
+++ b/shop3/tests/state-tests.lisp
@@ -176,8 +176,8 @@
 (test prop-sorter-type-mismatch
   "Test that PROP-SORTER is deterministic even under conditions of type
 mismatch."
-  (is (equal (sort `((1 2 3) (1 #(0 1 2)) (1 A) (1 ,(make-array '(2 2)))) 'prop-sorter)
-             (sort `((1 2 3) (1 ,(make-array '(2 2))) (1 #(0 1 2)) (1 A)) 'prop-sorter))))
+  (is (equalp (sort `((1 2 3) (1 #(0 1 2)) (1 A) (1 ,(make-array '(2 2)))) 'prop-sorter)
+              (sort `((1 2 3) (1 ,(make-array '(2 2))) (1 #(0 1 2)) (1 A)) 'prop-sorter))))
 
 (test prop-sorter-numerical-subtypes
   "Test that PROP-SORTER handles equal numbers of unequal types."


### PR DESCRIPTION
Old prop-sorter did not continue comparing past equal numeric elements.  This fixes that.

Fixes issue 186 (https://github.com/shop-planner/shop3/issues/186).