### PR TITLE
Extend debugging prints.

### DIFF
--- a/shop3/docs/shop3-manual.texinfo
+++ b/shop3/docs/shop3-manual.texinfo
@@ -776,25 +776,37 @@ will turn on tracing for @var{item}, which may be any
 of the following:
 @itemize
 @item
-a method, axiom, operator, task, or goal;
+the name of a method, axiom, operator, task, or predicate;
 @item
 one of the keywords @code{:methods}, @code{:axioms},
-@code{:operators}, @code{:tasks}, @code{:goals}, or
+@code{:operators}, @code{:tasks}, @code{:goals}, @code{:effects}, or
 @code{:protections} in which case @sysname{} will trace @emph{all}
-items of that type (@code{:goals} refers to predicates that are goals
-for the theorem-prover, and @code{:protections} refers to predicates
-used as arguments of @code{:protection} in operators);
+items of that type (@code{:goals}, @code{:effects}, and @code{:protections}
+refer to three different ways predicates can occur: as goals to
+be satisfied, as effects in operators, or as protections in operators);
+@item
+a pair of the form @code{(:task <taskname>)}, @code{(:method <methodname>)},
+@code{(:goal <goalname>)}, @code{(:axiom <axiomname>)}, or
+@code{(:operator <operatorname>)}.  @sysname{} will print trace outputs
+when attempting to expand the task, apply the method or operator,
+try to prove the goal, or use the axiom in the theorem-prover (e.g. when
+checking preconditions.
+
+Note that method and axiom names may not be what you expect!  Method
+names refer to the names of particular ways a task can be expanded,
+@emph{not} all the different decompositions in a single @code{:method}
+form, nor the task that the method expands.  For example, @code{(:method
+spoon-method)} (@pxref{Methods}).  Similarly, axiom names are
+@emph{branch names}, for example @code{(:axiom good)} (@pxref{Axioms}).
 @item
 the keyword @code{:states}, in which case @sysname{} will include the current state
 whenever it prints out a tracing message
 @item
-the keyword @code{:plans} in which case @sysname{} will print diagnostic information
-whenever it has found a plan (and may be considering whether or not to
-keep the plan, depending on the @code{:which} and @code{:optimize} arguments of
-@code{seek-plans}).
+the keyword @code{:effects}, in which case @sysname{} will trace the effects
+of operators being applied
 @item
-The keyword @code{:all}, which will trace all available items, currently
-methods, axioms, operators, tasks, goals and protections.
+the keyword @code{:all}, which will trace all available items, currently
+methods, axioms, operators, tasks, goals, effects, and protections.
 @end itemize
 
 @item
@@ -2005,8 +2017,10 @@ considered (through backtracking). Consequently, the following code:
 
 @lisp
 (:method (eat ?food)
+    fork-method
     (have-fork ?fork)
     ((!eat-with-fork ?food ?fork))
+    spoon-method
     (have-spoon ?spoon)
     ((!eat-with-spoon ?food ?spoon))
 @end lisp

--- a/shop3/io/debugging.lisp
+++ b/shop3/io/debugging.lisp
@@ -57,7 +57,7 @@
 ;;; portions thereof marked with this legend must also reproduce the
 ;;; markings.
 
-(in-package :shop2)
+(in-package :shop)
 
 (defvar *start-run-time*)
 (defvar *start-real-time*)
@@ -70,6 +70,7 @@
                                         ; expand one of these.
 (defvar *traced-axioms* nil)
 (defvar *traced-goals* nil)
+(defvar *traced-effects* nil)
 
 
 (defconstant +shop-trace-items+
@@ -93,10 +94,12 @@ currently being traced.
       be satisfied, and as effects or protections in operators);
     - a pair of the form (:TASK <taskname>), (:METHOD <methodname>).  SHOP will
       break when attempting to expand the task, or apply the method, respectively.
-    - the keyword :STATES, in which case SHOP will include the current
-      state whenever it prints out a tracing message
-    - the keyword :ALL in which case SHOP will print out all the tracing
-      information it knows how to.
+- the keyword :STATES, in which case SHOP will include the current
+       state whenever it prints out a tracing message
+     - the keyword :EFFECTS, in which case SHOP will trace the effects
+       of operators being applied
+     - the keyword :ALL in which case SHOP will print out all the tracing
+       information it knows how to.
 
  - (SHOP-TRACE ITEM1 ITEM2 ...) will do the same for a list of items"
   (let* ((items `,items)
@@ -117,15 +120,18 @@ currently being traced.
              (pushnew item *shop-trace*))
             ((listp item)
              (macrolet ((trace-item (variable)
-                          `(pushnew (second item) ,variable)))
+                          `(progn
+                             (pushnew item *shop-trace* :test 'equalp)
+                             (pushnew (second item) ,variable))))
                (case (car item)
                  (:task (trace-item *traced-tasks*))
                  (:method (trace-item *traced-methods*))
-		 (:operator (trace-item *traced-operators*))
+                 (:operator (trace-item *traced-operators*))
                  (:goal (trace-item *traced-goals*))
+                 (:effects (trace-item *traced-effects*))
                  (:axiom (trace-item *traced-axioms*))
                  (otherwise
-                  (warn "Ignoring invalid shop-trace argument ~S" item)))))
+                  (warn "Ignoring invalid shop-trace keyword ~s from argument ~S" (car item) item)))))
             (t
              (warn "Ignoring invalid shop-trace argument ~S" item)))))
   (shop-trace-info))
@@ -139,29 +145,38 @@ currently being traced.
 (defmethod trigger-trace ((keyword (eql :goals)) (item symbol))
   (member item *traced-goals* :test 'eq))
 
+(defmethod trigger-trace ((keyword (eql :effects)) (item symbol))
+  (member item *traced-effects* :test 'eq))
+
+
 (defmethod trigger-trace ((keyword (eql :tasks)) (item symbol))
   (member item *traced-tasks* :test 'eq))
+
+(defmethod trigger-trace ((keyword (eql :operators)) (item symbol))
+  (member item *traced-operators* :test 'eq))
 
 
 (defun shop-trace-info ()
   "Information about the traced aspects of shop3."
-  (append
-   *shop-trace*
-   (mapcar #'(lambda (taskname)
-               `(:task ,taskname))
-           *traced-tasks*)
-   (mapcar #'(lambda (methname)
-               `(:method ,methname))
-           *traced-methods*)
-   (mapcar #'(lambda (opname)
-               `(:operator ,opname))
-           *traced-operators*)
-   (mapcar #'(lambda (goalname)
-               `(:goal ,goalname))
-           *traced-goals*)
-   (mapcar #'(lambda (axiomname)
-               `(:axiom ,axiomname))
-           *traced-axioms*)))
+  (remove-duplicates
+   (append
+    *shop-trace*
+    (mapcar #'(lambda (taskname)
+                `(:task ,taskname))
+            *traced-tasks*)
+    (mapcar #'(lambda (methname)
+                `(:method ,methname))
+            *traced-methods*)
+    (mapcar #'(lambda (opname)
+                `(:operator ,opname))
+            *traced-operators*)
+    (mapcar #'(lambda (goalname)
+                `(:goal ,goalname))
+            *traced-goals*)
+    (mapcar #'(lambda (axiomname)
+                `(:axiom ,axiomname))
+            *traced-axioms*))
+   :test 'equalp))
 
 
 (defmacro shop-untrace (&rest items)
@@ -172,11 +187,12 @@ currently being traced.
 
 (defun shop-untrace-all ()
   (setf *shop-trace* nil
-       *traced-tasks* nil
-       *traced-operators* nil
-       *traced-methods* nil
-       *traced-goals* nil
-       *traced-axioms* nil))
+        *traced-tasks* nil
+        *traced-operators* nil
+        *traced-methods* nil
+        *traced-goals* nil
+        *traced-effects* nil
+        *traced-axioms* nil))
 
 
 (defun shop-untrace-1 (items)
@@ -186,13 +202,19 @@ currently being traced.
            (shop-untrace-all))
           ((symbolp item)
            (setq *shop-trace* (delete item *shop-trace*)))
-         ((eq (car item) :task)
-          (setf *traced-tasks* (delete (second item) *traced-tasks*)))
-         ((eq (car item) :method)
-          (setf *traced-methods* (delete (second item) *traced-methods*)))
-         (t
-          (warn "don't know how to delete ~S from shop-trace items: ignoring."
-                item)))))
+          ((eq (car item) :task)
+           (setf *traced-tasks* (delete (second item) *traced-tasks*)))
+          ((eq (car item) :method)
+           (setf *traced-methods* (delete (second item) *traced-methods*)))
+          ((eq (car item) :goal)
+           (setf *traced-goals* (delete (second item) *traced-goals*)))
+          ((eq (car item) :effects)
+           (setf *traced-effects* (delete (second item) *traced-effects*)))
+          ((eq (car item) :axiom)
+           (setf *traced-axioms* (delete (second item) *traced-axioms*)))
+          (t
+           (warn "don't know how to delete ~S from shop-trace items: ignoring."
+                 item)))))
 
 (defun print-methods (&optional name (domain *domain*))
   (if name

--- a/shop3/io/debugging.lisp
+++ b/shop3/io/debugging.lisp
@@ -91,15 +91,17 @@ currently being traced.
       :GOALS, :EFFECTS, or :PROTECTIONS, in which case SHOP will
       trace all items of that type (:GOALS, :EFFECTS, and :PROTECTIONS
       refer to three different ways predicates can occur: as goals to
-      be satisfied, and as effects or protections in operators);
-    - a pair of the form (:TASK <taskname>), (:METHOD <methodname>).  SHOP will
-      break when attempting to expand the task, or apply the method, respectively.
-- the keyword :STATES, in which case SHOP will include the current
-       state whenever it prints out a tracing message
-     - the keyword :EFFECTS, in which case SHOP will trace the effects
-       of operators being applied
-     - the keyword :ALL in which case SHOP will print out all the tracing
-       information it knows how to.
+      be satisfied, as effects in operators, or as protections in operators);
+    - a pair of the form (:TASK <taskname>), (:METHOD <methodname>),
+       (:GOAL <goalname>), (:AXIOM <axiomname>), or (:OPERATOR <operatorname>).
+       SHOP will break when attempting to expand the task, apply the method, or
+       trace the goal/axiom/operator.
+    - the keyword :STATES, in which case SHOP will include the current
+        state whenever it prints out a tracing message
+    - the keyword :EFFECTS, in which case SHOP will trace the effects
+        of operators being applied
+    - the keyword :ALL in which case SHOP will print out all the tracing
+        information it knows how to.
 
  - (SHOP-TRACE ITEM1 ITEM2 ...) will do the same for a list of items"
   (let* ((items `,items)
@@ -154,6 +156,10 @@ currently being traced.
 
 (defmethod trigger-trace ((keyword (eql :operators)) (item symbol))
   (member item *traced-operators* :test 'eq))
+
+(defmethod trigger-trace ((keyword (eql :plans)) item)
+  (declare (ignorable keyword item))
+  nil)
 
 
 (defun shop-trace-info ()

--- a/shop3/io/debugging.lisp
+++ b/shop3/io/debugging.lisp
@@ -62,14 +62,13 @@
 (defvar *start-run-time*)
 (defvar *start-real-time*)
 
-;; (defvar *traced-operators* nil)      ; break when attempting to
+(defvar *traced-operators* nil)      ; break when attempting to
                                         ; apply one of these.
 (defvar *traced-methods* nil)           ; break when attempting to
                                         ; apply one of these.
 (defvar *traced-tasks* nil)             ; break when attempting to
                                         ; expand one of these.
-(defvar *traced-axioms*
-  nil)
+(defvar *traced-axioms* nil)
 (defvar *traced-goals* nil)
 
 
@@ -122,6 +121,7 @@ currently being traced.
                (case (car item)
                  (:task (trace-item *traced-tasks*))
                  (:method (trace-item *traced-methods*))
+		 (:operator (trace-item *traced-operators*))
                  (:goal (trace-item *traced-goals*))
                  (:axiom (trace-item *traced-axioms*))
                  (otherwise
@@ -153,6 +153,9 @@ currently being traced.
    (mapcar #'(lambda (methname)
                `(:method ,methname))
            *traced-methods*)
+   (mapcar #'(lambda (opname)
+               `(:operator ,opname))
+           *traced-operators*)
    (mapcar #'(lambda (goalname)
                `(:goal ,goalname))
            *traced-goals*)
@@ -170,7 +173,7 @@ currently being traced.
 (defun shop-untrace-all ()
   (setf *shop-trace* nil
        *traced-tasks* nil
-       ;;*traced-operators* nil
+       *traced-operators* nil
        *traced-methods* nil
        *traced-goals* nil
        *traced-axioms* nil))

--- a/shop3/io/debugging.lisp
+++ b/shop3/io/debugging.lisp
@@ -1,4 +1,4 @@
-;;;
+;;
 ;;; Version: MPL 1.1/GPL 2.0/LGPL 2.1
 ;;;
 ;;; The contents of this file are subject to the Mozilla Public License
@@ -158,6 +158,10 @@ currently being traced.
   (member item *traced-operators* :test 'eq))
 
 (defmethod trigger-trace ((keyword (eql :plans)) item)
+  (declare (ignorable keyword item))
+  nil)
+
+(defmethod trigger-trace ((keyword (eql :protections)) item)
   (declare (ignorable keyword item))
   nil)
 

--- a/shop3/io/debugging.lisp
+++ b/shop3/io/debugging.lisp
@@ -85,7 +85,7 @@ currently being traced.
  - (SHOP-TRACE ITEM) will turn on tracing for ITEM.
 
  ITEM may be any of the following:
- 
+
     - the name of a method, axiom, operator, task, or predicate;
     - one of the keywords :METHODS, :AXIOMS, :OPERATORS, :TASKS,
       :GOALS, :EFFECTS, or :PROTECTIONS, in which case SHOP will
@@ -118,8 +118,7 @@ currently being traced.
              (pushnew item *shop-trace*))
             ((listp item)
              (macrolet ((trace-item (variable)
-                          `(progn (pushnew (second item) ,variable)
-                                  (pushnew item *shop-trace*))))
+                          `(pushnew (second item) ,variable)))
                (case (car item)
                  (:task (trace-item *traced-tasks*))
                  (:method (trace-item *traced-methods*))
@@ -180,14 +179,14 @@ currently being traced.
 (defun shop-untrace-1 (items)
   ;; it's OK to use destructive deletion here
   (dolist (item items)
-    (cond ((symbolp item)
-          (setq *shop-trace* (delete item *shop-trace*)))
+    (cond ((eq item :all)
+           (shop-untrace-all))
+          ((symbolp item)
+           (setq *shop-trace* (delete item *shop-trace*)))
          ((eq (car item) :task)
           (setf *traced-tasks* (delete (second item) *traced-tasks*)))
          ((eq (car item) :method)
           (setf *traced-methods* (delete (second item) *traced-methods*)))
-         ((eq (car item) :all)
-          (shop-untrace-all))
          (t
           (warn "don't know how to delete ~S from shop-trace items: ignoring."
                 item)))))

--- a/shop3/pddl/pddl.lisp
+++ b/shop3/pddl/pddl.lisp
@@ -849,7 +849,7 @@ Otherwise it returns FAIL."
                     (add-protection protections (second a)
                                     depth (first head) state))))
 
-          (trace-print :operators action state "~&PDDL action ~A successfully applied." head-subbed)
+          (trace-print :operators (first head) state "~&PDDL action ~A successfully applied." head-subbed)
 
           (values head-subbed statetag
                   protections cost-number

--- a/shop3/planning-engine/task-reductions.lisp
+++ b/shop3/planning-engine/task-reductions.lisp
@@ -103,10 +103,10 @@ Otherwise it returns FAIL."
     ;; non-local exit
     (when (eq operator-unifier 'fail)
       (trace-print :operators (first head) state
-                       "~2%Depth ~d, inapplicable operator ~s~%     task ~s.~%     Unification of task and operator failed.~%"
+                       "~2%Depth ~d, inapplicable operator ~s with head ~s~%     task ~s.~%     Unification of task and operator failed.~%"
                        depth
-                       (first head)
-                       (apply-substitution task-body operator-unifier))
+                       (first head) head
+                       (apply-substitution task-body in-unifier))
       (return-from apply-operator 'fail))
 
     (setf operator-unifier

--- a/shop3/planning-engine/task-reductions.lisp
+++ b/shop3/planning-engine/task-reductions.lisp
@@ -196,7 +196,7 @@ Otherwise it returns FAIL."
                 (add-protection protections (second a)
                                 depth (first head) state))))
 
-      (trace-print :operators operator state "~&Operator successfully applied.")
+      (trace-print :operators (operator-name operator) state "~&Operator successfully applied.")
 
       (values head-subbed statetag
               protections cost-number

--- a/shop3/planning-engine/task-reductions.lisp
+++ b/shop3/planning-engine/task-reductions.lisp
@@ -311,9 +311,12 @@ Otherwise it returns FAIL."
                      task-body)
 
         ;; find all matches to the current state
-        (multiple-value-setq (state-unifiers dependencies)
-          (shopthpr:find-satisfiers pre state
-                                    :domain domain))
+        (let ((*shop-trace* (if (member method-name *traced-methods*)
+                               (cons :goals *shop-trace*)
+                               *shop-trace*)))
+          (multiple-value-setq (state-unifiers dependencies)
+            (shopthpr:find-satisfiers pre state
+                                      :domain domain)))
         (if state-unifiers
             (let* ((answers-with-duplicates
                      (if *record-dependencies-p*

--- a/shop3/theorem-prover/theorem-prover.lisp
+++ b/shop3/theorem-prover/theorem-prover.lisp
@@ -517,7 +517,7 @@ in the goal, so we ignore the extra reference."
       ;; the negation is falsified
       nil)
     (t
-     (trace-print :goals (car arguments) state
+     (trace-print :goals (caar arguments) state
                   "~2%Level ~s, NOT goal ~s succeeded (positive goal unsatisfied)" newlevel arguments)
      (let (newdep)
        ;; FIXME: this really only works if we convert the preconditions to negation normal form.

--- a/shop3/theorem-prover/theorem-prover.lisp
+++ b/shop3/theorem-prover/theorem-prover.lisp
@@ -511,21 +511,23 @@ in the goal, so we ignore the extra reference."
       (cerror "Simply return no new dependencies." 'incomplete-dependency-error :logical-op "negation (NOT)" :expression arguments)
       ))
   ;; we just want to see if (CDR GOAL1) is satisfiable, so last arg is T
-  (cond
-    ((let ((*record-dependencies-p* nil))
-       (seek-satisfiers arguments state nil newlevel t :domain domain))
-     ;; the negation is falsified
-     nil)
-   (t
-    (let (newdep)
-      ;; FIXME: this really only works if we convert the preconditions to negation normal form.
-      (when (and *record-dependencies-p* (groundp (first arguments)))
-        (setf newdep
-              (make-raw-depend
-               :est
-               (dependency-for-negation (first arguments) state)
-               :prop `(not ,(first arguments)))))
-      (seek-satisfiers other-goals state bindings newlevel just1 :domain domain :dependencies (if newdep (cons newdep dependencies-in) dependencies-in))))))
+(cond
+     ((let ((*record-dependencies-p* nil))
+        (seek-satisfiers arguments state nil newlevel t :domain domain))
+      ;; the negation is falsified
+      nil)
+    (t
+     (trace-print :goals (car arguments) state
+                  "~2%Level ~s, NOT goal ~s succeeded (positive goal unsatisfied)" newlevel arguments)
+     (let (newdep)
+       ;; FIXME: this really only works if we convert the preconditions to negation normal form.
+       (when (and *record-dependencies-p* (groundp (first arguments)))
+         (setf newdep
+               (make-raw-depend
+                :est
+                (dependency-for-negation (first arguments) state)
+                :prop `(not ,(first arguments)))))
+       (seek-satisfiers other-goals state bindings newlevel just1 :domain domain :dependencies (if newdep (cons newdep dependencies-in) dependencies-in))))))
 
 (defun dependency-for-negation (positive-literal state)
   ;; FIXME: we should check that positive-literal is, in fact, a

--- a/shop3/unification/tracer.lisp
+++ b/shop3/unification/tracer.lisp
@@ -92,4 +92,4 @@
               (when (fboundp s-a)
                 `(when (member :states *shop-trace*)
                    (format *shop-trace-stream* "~%     state ~s"
-                           (sort (,s-a ,state) ',pred)))))))))))
+                           (sort (,s-a ,state) ',pred))))))))))

--- a/shop3/unification/tracer.lisp
+++ b/shop3/unification/tracer.lisp
@@ -73,7 +73,8 @@
 
 (defmacro trace-print (type item state &rest formats)
   `(when *shop-trace*
-     (when (or (member ,type *shop-trace*) (member ,item *shop-trace*)
+     (when (or (member ,type *shop-trace*)
+               (member ,item *shop-trace*)
                (trigger-trace ,type ,item))
        ,(let ((cpack (find-package :shop2.common)))
           (when cpack

--- a/shop3/unification/tracer.lisp
+++ b/shop3/unification/tracer.lisp
@@ -65,7 +65,10 @@
 (defgeneric trigger-trace (keyword item-name)
   (:documentation "Allow extensible methods of matching to trigger printing.")
   (:method (keyword item-name)
-    (declare (ignorable keyword item-name))
+    (declare (ignorable item-name))
+    (cerror "Continue, skipping the trace."
+            "Used unsupported trace keyword ~S in ~S"
+            keyword (list keyword item-name))
     nil))
 
 (defmacro trace-print (type item state &rest formats)

--- a/shop3/unification/tracer.lisp
+++ b/shop3/unification/tracer.lisp
@@ -73,6 +73,8 @@
 
 (defmacro trace-print (type item state &rest formats)
   `(when *shop-trace*
+     (unless (symbolp ,item)
+       (error 'type-error :expected-type 'symbol :datum ,item))
      (when (or (member ,type *shop-trace*) (member ,item *shop-trace*)
                (trigger-trace ,type ,item))
        ,(let ((cpack (find-package :shop2.common)))
@@ -90,4 +92,4 @@
               (when (fboundp s-a)
                 `(when (member :states *shop-trace*)
                    (format *shop-trace-stream* "~%     state ~s"
-                     (sort (,s-a ,state) ',pred))))))))))
+                           (sort (,s-a ,state) ',pred))))))))))


### PR DESCRIPTION
Better trace info when a negated goal is satisfied.
When a method is traced, trace the attempt to satisfy its
preconditions.

Includes changes from ko-patch-1.  See notes on closed PR #164

To do list from #164:


- [x] `(shop-trace (:method ))` works, but needs what in the manual is denoted [nm] or [n1], [n2] etc. This could be made clearer in the manual.  Also this causes a break, which is undesirable.
- [ ] `:goal` tracing prints too much.  Too much about state access. Needs re-think, maybe a _level_ of tracing, not just what to trace.
- [x] Does *named* `:goal` tracing work?
- [x] `(shop-trace (:operator ))` does nothing
- [x] `(shop-trace (:task ))` works.
- [x] `(shop-trace (:axiom ))` doesn't do anything.
   - Actually, this is not true: it's just that you need the _branch name_ for the axiom (see discussion of `:method` tracing). So this also needs a manual update.
- [x] Global tracing of `:method`, `:task`s, `:operator`s, `:axiom`s works fine. 
- [ ] Separate tracing from breaking. I find mostly I do _not_ want to break on matching methods (sometimes yes, but not always).  Add `*break-on-trace*` for global control? Add a `:break` option for `(shop-trace (:method <foo> :break))`?  Ideas welcomed in comments!
