### PR TITLE
Fix umt-domain for :which :all

### DIFF
--- a/shop3/tests/umt-domain/operators.lisp
+++ b/shop3/tests/umt-domain/operators.lisp
@@ -628,5 +628,10 @@
                    ()
                    ((connect-loc ?road ?type ?l1 ?l2))
                    ())
+
+        (:operator (!!do-nothing)
+                   ()
+                   ()
+                   ())
         
    ))


### PR DESCRIPTION
Domain was missing a defn for !!do-nothing operator which caused error when generating many plans, eg:

```
No operator for task (:TASK :IMMEDIATE !!DO-NOTHING)
   [Condition of type SIMPLE-ERROR]

Restarts:
 0: [RETRY] Retry SLY mREPL evaluation request.
 1: [*ABORT] Return to SLY's top level.
 2: [ABORT] abort thread (#<THREAD tid=11551 "sly-channel-1-mrepl-remote-1" RUNNING {700864C053}>)

Backtrace:
 0: (SHOP3::SEEK-PLANS-PRIMITIVE-1 #<DOMAIN PARTITIONED-UM-TRANSLOG-2> (:TASK :IMMEDIATE !!DO-NOTHING) #<SHOP3.COMMON::MIXED-STATE {7000CC8033}> (:ORDERED (:UNORDERED (:ORDERED #) (:ORDERED #)) (:TASK !CL..
 1: ((:METHOD SHOP3::EXPAND-PRIMITIVE-STATE (T DOMAIN)) #<SHOP3::SEARCH-STATE {7000CA9393}> #<DOMAIN PARTITIONED-UM-TRANSLOG-2>) [fast-method]
 2: (SHOP3::SEEK-PLANS-STACK #<SHOP3::SEARCH-STATE {7000CA9393}> #<DOMAIN PARTITIONED-UM-TRANSLOG-2> :WHICH :ALL :REPAIRABLE NIL :UNPACK-RETURNS T :PLAN-NUM-LIMIT 1)
 3: (FIND-PLANS-STACK UMT-PARTITIONED.PFILE1 :DOMAIN NIL :VERBOSE 0 :PLAN-TREE NIL :GC NIL :NO-DEPENDENCIES NIL :REPAIRABLE NIL :STATE-TYPE :MIXED :OUT-STREAM T :WHICH :ALL :PLAN-NUM-LIMIT 1 :ANALOGICAL-R..
 4: (SB-INT:SIMPLE-EVAL-IN-LEXENV (FIND-PLANS-STACK (QUOTE UMT-PARTITIONED.PFILE1) :WHICH :ALL) #<NULL-LEXENV>)
 5: (EVAL (FIND-PLANS-STACK (QUOTE UMT-PARTITIONED.PFILE1) :WHICH :ALL))
 6: ((LAMBDA NIL :IN SLYNK-MREPL::MREPL-EVAL-1))
 --more--

```

After fix, generates 10,170 plans.