### PR TITLE
Add trigger-trace method for :protections.

### DIFF
--- a/shop3/io/debugging.lisp
+++ b/shop3/io/debugging.lisp
@@ -1,4 +1,4 @@
-;;;
+;;
 ;;; Version: MPL 1.1/GPL 2.0/LGPL 2.1
 ;;;
 ;;; The contents of this file are subject to the Mozilla Public License
@@ -158,6 +158,10 @@ currently being traced.
   (member item *traced-operators* :test 'eq))
 
 (defmethod trigger-trace ((keyword (eql :plans)) item)
+  (declare (ignorable keyword item))
+  nil)
+
+(defmethod trigger-trace ((keyword (eql :protections)) item)
   (declare (ignorable keyword item))
   nil)
 

--- a/shop3/unification/tracer.lisp
+++ b/shop3/unification/tracer.lisp
@@ -73,7 +73,8 @@
 
 (defmacro trace-print (type item state &rest formats)
   `(when *shop-trace*
-     (when (or (member ,type *shop-trace*) (member ,item *shop-trace*)
+     (when (or (member ,type *shop-trace*)
+               (member ,item *shop-trace*)
                (trigger-trace ,type ,item))
        ,(let ((cpack (find-package :shop2.common)))
           (when cpack


### PR DESCRIPTION
```
 (asdf:load-system :shop3/test)
 (shop-trace :tasks)
 (shop-user::define-partitioned-umt-domain)
 (find-plans-stack 'shop-user::umt-partitioned.pfile1)
```
->
```
Used unsupported trace keyword :PROTECTIONS in (:PROTECTIONS
                                                NEXT)
   [Condition of type SIMPLE-ERROR]

Restarts:
 0: [CONTINUE] Continue, skipping the trace.
 1: [RETRY] Retry SLY mREPL evaluation request.
 2: [*ABORT] Return to SLY's top level.
 3: [ABORT] abort thread (#<THREAD tid=16323 "sly-channel-1-mrepl-remote-1" RUNNING {700863C053}>)

Backtrace:
 0: ((:METHOD SHOP3.UNIFIER:TRIGGER-TRACE (T T)) :PROTECTIONS NEXT) [fast-method]
 1: (SHOP3::ADD-PROTECTION NIL (NEXT TRUCK2 LOCATION4) 87 !!ADD-NEXT #<SHOP3.COMMON::MIXED-STATE {70010D3F93}>)
 2: ((:METHOD APPLY-OPERATOR (DOMAIN T T T T T T)) #<DOMAIN PARTITIONED-UM-TRANSLOG-2> #<SHOP3.COMMON::MIXED-STATE {70010D3F93}> (!!ADD-NEXT TRUCK2 LOCATION
```