### PR TITLE
Fix issue 177: returning plan trees from multiple plans

### DIFF
--- a/shop3/explicit-stack-search/explicit-search.lisp
+++ b/shop3/explicit-stack-search/explicit-search.lisp
@@ -316,6 +316,7 @@ List of analogical-replay tables -- optional
                (when success
                  (setf plan-return
                        (make-plan-return domain which
+                                         :plan-num-limit plan-num-limit
                                          :plan plan
                                          :state state
                                          :repairable repairable
@@ -359,13 +360,13 @@ the tasks in the original PLAN into the copy.
 equality, so when the plan is rewritten, any plan tree must be rewritten,
 as well."
   (iter (with lookup-table = (make-hash-table :test #'eq))
-               (declare (ignorable rest))
-               (for (task num . rest) on plan by 'cddr)
-               (as copied-task = (copy-tree task))
-               (collecting copied-task into plan-copy)
-               (collecting num into plan-copy)
-               (setf (gethash task lookup-table) copied-task)
-               (finally (return (values plan-copy lookup-table)))))
+    (declare (ignorable rest))
+    (for (task num . rest) on plan by 'cddr)
+    (as copied-task = (copy-tree task))
+    (collecting copied-task into plan-copy)
+    (collecting num into plan-copy)
+    (setf (gethash task lookup-table) copied-task)
+    (finally (return (values plan-copy lookup-table)))))
 
 ;;; Internal function, just a helper for `make-plan-return`.
 (declaim (inline populate-plan-return))
@@ -375,14 +376,19 @@ as well."
 #-sbcl                                  ; SBCL doesn't like FTYPE declaration for a generic function.
 (declaim
  (ftype
-  (function (domain symbol &key (:state t) (:repairable t) (:plan list) (:replay-table (or null hash-table)) &allow-other-keys)
+  (function (domain symbol &key (:state t)
+                    (:repairable t)
+                    (:plan list)
+                    (:replay-table (or null hash-table))
+                    (plan-num-limit (or null integer)) &allow-other-keys)
             (values plan-return &optional))
   make-plan-return))
 
-(defgeneric make-plan-return (domain which &key state plan replay-table repairable &allow-other-keys)
+(defgeneric make-plan-return (domain which &key state plan replay-table repairable plan-num-limit &allow-other-keys)
   (:documentation "Make and return a PLAN-RETURN structure.  How return values are collected
-is directed by DOMAIN and WHICH arguments.")
-  (:method ((domain domain) (which (eql :all)) &key state plan replay-table repairable)
+ is directed by DOMAIN and WHICH arguments.")
+  (:method ((domain domain) (which (eql :all)) &key state plan replay-table repairable plan-num-limit)
+    (declare (ignore plan-num-limit))
     (assert (not repairable))
     ;; if there are going to be multiple return values, we must make
     ;; sure that further search does not clobber them.
@@ -392,7 +398,7 @@ is directed by DOMAIN and WHICH arguments.")
         (multiple-value-bind (new-plan new-tree)
             (prv:prepare-return-values plan :bindings (unifier state)
                                             :plan-tree (when (slot-boundp state 'plan-tree)
-                                                    (plan-tree state)))
+                                                         (plan-tree state)))
           (populate-plan-return
            :plan new-plan
            :tree new-tree
@@ -401,18 +407,22 @@ is directed by DOMAIN and WHICH arguments.")
            :world-state (copy-state (world-state state))
            :replay-table (when replay-table
                            (alexandria:copy-hash-table replay-table))))))
-  (:method ((domain domain) (which (eql :first)) &key plan state replay-table repairable)
-    (populate-plan-return
-     :plan plan
-     :tree (when *enhanced-plan-tree*
-             (apply-substitution-to-tree (unifier state) (plan-tree state))
-             (plan-tree state))
-     :lookup-table (when *enhanced-plan-tree*
-                     (plan-tree-lookup state))
-     :search-state (when repairable state)
-     :world-state (world-state state)
-     :replay-table (when replay-table
-                     (alexandria:copy-hash-table replay-table)))))
+  (:method ((domain domain) (which (eql :first)) &key plan state replay-table repairable plan-num-limit)
+    (if (> plan-num-limit 1)
+        ;; if we are looking for more than a single plan, then we must build the plan return in the same
+        ;; way as if we were finding all plans.
+        (make-plan-return domain :all :plan plan :state state :replay-table replay-table :repairable repairable)
+        (populate-plan-return
+         :plan plan
+         :tree (when *enhanced-plan-tree*
+                 (apply-substitution-to-tree (unifier state) (plan-tree state))
+                 (plan-tree state))
+         :lookup-table (when *enhanced-plan-tree*
+                         (plan-tree-lookup state))
+         :search-state (when repairable state)
+         :world-state (world-state state)
+         :replay-table (when replay-table
+                         (alexandria:copy-hash-table replay-table))))))
 
 
 (defun plan-returns (pr-list &optional (unpack-returns t))

--- a/shop3/explicit-stack-search/prepare-return-values.lisp
+++ b/shop3/explicit-stack-search/prepare-return-values.lisp
@@ -134,9 +134,11 @@ hash tables. Done for side-effects: returns nothing."
 
 (defun translate-dependency-links (new-root tree-translation-table)
   (flet ((translate-node (node)
-           (declare (type tree-node node))
-           (or (gethash node tree-translation-table)
-               (error "Tree translation table has no translation for node ~s" node))))
+           (declare (type (or tree-node (eql :init)) node))
+           (cond ((eq node :init) :init)
+                 ((gethash node tree-translation-table))
+                 (t
+                  (error "Tree translation table has no translation for node ~s" node)))))
     (declare (ftype (function (tree-node) (values tree-node &optional))
                     translate-node))
     (flet ((translate-dependency (d)

--- a/shop3/explicit-stack-search/prepare-return-values.lisp
+++ b/shop3/explicit-stack-search/prepare-return-values.lisp
@@ -48,33 +48,40 @@ copies of the originals, with the BINDINGS applied."
                             :size size))
          new-root)
     (iter (with open = (list plan-tree))
-      (while open)
-      (for node = (pop open))
-      (as new-node = (copy-plan-tree-node node))
-      ;; make a new node and index the copy against the original node
-      (setf (gethash node tree-translation-table) new-node)
-      (when (typep new-node 'top-node)
-        (unless (null new-root) (error "Apparently two root nodes in tree."))
-        (setf new-root
-              new-node
-              (top-node-lookup-table new-node)
-              new-lookup-table))
-      (if (typep node 'primitive-tree-node)
-          (progn
-            ;; FIXME: the second disjunct here should not be necessary
-            ;; -- need to revisit how primitive tree nodes are set. [2023/05/02:rpg]
-            (assert (or (null (tree-node-expanded-task node))
-                        (equalp (tree-node-expanded-task node)
-                                (tree-node-task node))))
-           (setf (tree-node-task new-node)
-                 (when-let (tsk (tree-node-task node))
-                   (gethash tsk translation-table))))
-          (setf (tree-node-task new-node)
-                (apply-substitution (copy-tree (tree-node-task node)) bindings)
-                (tree-node-expanded-task new-node)
-                (copy-tree (tree-node-expanded-task node))))
-      (unless (typep node 'primitive-tree-node)
-        (setf open (append (complex-tree-node-children node) open))))
+          (while open)
+          (for node = (pop open))
+          (as new-node = (copy-plan-tree-node node))
+          ;; make a new node and index the copy against the original node
+          (setf (gethash node tree-translation-table) new-node)
+          (when (typep new-node 'top-node)
+            (unless (null new-root) (error "Apparently two root nodes in tree."))
+            (setf new-root
+                  new-node
+                  (top-node-lookup-table new-node)
+                  new-lookup-table))
+          (if (typep node 'primitive-tree-node)
+              (progn
+                ;; FIXME: the second disjunct here should not be necessary
+                ;; -- need to revisit how primitive tree nodes are set. [2023/05/02:rpg]
+                (assert (or (null (tree-node-expanded-task node))
+                            (equalp (tree-node-expanded-task node)
+                                    (tree-node-task node))))
+                (let ((tsk (tree-node-task node)))
+                  (setf (tree-node-task new-node)
+                        (when tsk (gethash tsk translation-table))))
+                (when-let ((tsk (tree-node-expanded-task node)))
+                  (setf (tree-node-expanded-task new-node)
+                        (cond ((gethash tsk translation-table)) ; already an entry
+                              ;; we don't have a translation table entry for this, so we need to make one
+                              (t
+                               (setf (gethash tsk translation-table)
+                                     (copy-tree tsk)))))))
+              (setf (tree-node-task new-node)
+                    (apply-substitution (copy-tree (tree-node-task node)) bindings)
+                    (tree-node-expanded-task new-node)
+                    (copy-tree (tree-node-expanded-task node))))
+          (unless (typep node 'primitive-tree-node)
+            (setf open (append (complex-tree-node-children node) open))))
     (values new-root tree-translation-table)))
 
 
@@ -139,7 +146,8 @@ hash tables. Done for side-effects: returns nothing."
                  ((gethash node tree-translation-table))
                  (t
                   (error "Tree translation table has no translation for node ~s" node)))))
-    (declare (ftype (function (tree-node) (values tree-node &optional))
+    (declare (ftype (function ((or tree-node (eql :init)))
+                              (values (or tree-node (eql :init)) &optional))
                     translate-node))
     (flet ((translate-dependency (d)
              (make-dependency

--- a/shop3/minimal-subtree/package.lisp
+++ b/shop3/minimal-subtree/package.lisp
@@ -2,6 +2,10 @@
 
 (defpackage shop3-minimal-subtree
   (:nicknames #:shop-minimal-subtree #:subtree #:shop2-minimal-subtree)
-  (:shadowing-import-from #:plan-tree #:tree-node-task #:tree-node #:copy-plan-tree)
+  (:shadowing-import-from #:plan-tree
+                          #:tree-node-task
+                          #:tree-node
+                          #:copy-plan-tree
+                          #:all-primitive-nodes)
   (:export #:find-failed-task)
   (:use common-lisp iterate shop plan-tree))

--- a/shop3/package.lisp
+++ b/shop3/package.lisp
@@ -368,6 +368,9 @@
            #:find-tree-node-if
            #:find-all-tree-nodes-if
 
+           ;; warning! this collides with shop3:all-primitive-nodes
+           #:all-primitive-nodes
+
            #:copy-plan-tree
            #:plan-tree->sexp
            ))

--- a/shop3/pddl/pddl.lisp
+++ b/shop3/pddl/pddl.lisp
@@ -226,6 +226,8 @@ PDDL operator definitions.")
     :initarg :%pddl-types              ; don't use the initform -- it's for testing.
    )))
 
+
+
 (defclass costs-mixin ()
   ())
 
@@ -321,8 +323,11 @@ later be compiled into find-satisfiers or something."
   (let ((types-def (find :types items :key 'first)))
     ;; if there's no type definition, add a trivial one.
     (unless types-def (setf (pddl-types domain) '(object)))
-    (call-next-method domain `(,@(if types-def (remove types-def items) items)
-                               ,@(when types-def (list types-def))))))
+    ;; OBJECT is the built-in top type in PDDL.
+    (prog1
+        (call-next-method domain `(,@(if types-def (remove types-def items) items)
+                                   ,@(when types-def (list types-def))))
+      (pushnew 'object (pddl-types domain)))))
 
 ;;;---------------------------------------------------------------------------
 ;;; Translating derived predicates

--- a/shop3/shop3.asd
+++ b/shop3/shop3.asd
@@ -313,9 +313,9 @@ minimal affected subtree."
                (search-tests . :search-tests) ; 9
                (plan-num-limit-tests . :plan-num-limit-tests) ; 25
                (hddl-plan-tests . :shop-hddl-tests) ; 7
-               (new-plan-tree-tests . :new-plan-tree-tests) ; 22
+               (new-plan-tree-tests . :new-plan-tree-tests) ; 722
                )
-  :num-checks 1337
+  :num-checks 2037
   :depends-on ((:version "shop3" (:read-file-form "shop-version.lisp-expr"))
                "shop3/openstacks"
                "shop3/depots"

--- a/shop3/tests/new-plan-tree-tests.lisp
+++ b/shop3/tests/new-plan-tree-tests.lisp
@@ -8,6 +8,7 @@
                 #:find-plans-stack
                 #:shorter-plan
                 #:task-name
+                #:defdomain
                 #:internal-operator-p)
   (:import-from #:plan-tree
                 #:make-tree-and-plan
@@ -18,7 +19,7 @@
                 #:compare-trees
                 #:tree-node-expanded-task
                 #:primitive-tree-node-p
-                )
+                #:all-primitive-nodes)
   (:import-from #:hddl-translator
                 #:*task-indices*
                 #:*next-index*
@@ -159,3 +160,528 @@
     (let ((tree3 (shop-hddl:hddl-plan (tree-and-plan-plan pt2) (tree-and-plan-tree pt2)
                                       :if-not-ground :ignore)))
       (is (equalp tree1 tree3)))))
+
+
+(in-package :shop3-user)
+
+(defmacro new-plan-tree-tests::test-hopping-domain (&body body)
+  `(progn
+     (let ((*package* (find-package :shop3-user)))
+       (defdomain (test-hopping :type pddl-domain :silently t)
+           ((:include ste-test-domain ,(asdf:system-relative-pathname "shop3" "tests/st-test-domain.pddl"))
+
+            (:method (win)
+              ((:goal (attacker-owns-core-dump ?proc)))
+              (:ordered
+               ;;(make-mem-block-contents mem-block-core-pattern-buffer-plus-2 corrupt-path)
+               (write-corrupt-path-to-cpb corrupt-path)
+               (!kill-process ?proc)))
+
+            (:method (write-corrupt-path-to-cpb corrupt-path)
+              ()
+              (:ordered
+               (find-mem-block mem-block-core-pattern-buffer)
+               (!compute-mem-block-addr-core-pat-plus-2 mem-block-core-pattern-buffer
+                                                        mem-block-core-pattern-buffer-plus-2)
+               (make-mem-block-contents mem-block-core-pattern-buffer-plus-2 corrupt-path)))
+
+            (:method (make-mem-block-contents ?mb ?contents)
+              mbc-already-done
+              (mem-block-contents ?mb ?contents)
+              ()
+              mb-needs-doing
+              ()
+              ((find-mem-block ?mb)
+               (write-mem-block-contents ?mb ?contents)))
+
+            (:method (write-mem-block-contents ?mb ?contents)
+              use-ace2
+              ;; if the ?contents is pointer to some memory buffer
+              ;; whose address we know, then we can use ACE2
+              (and (not (ace2-used))
+                   ;; the following will be established by the
+                   ;; first task in the task net.
+                   ;; (know-addr-of ?mb)
+                   ;; the following is failing for the target that is the
+                   ;; offset into the
+                   (or (ste-data-addr ?mb ?mbptr)
+                       (addr ?mb ?mbptr))
+                   (pointer ?mbptr)
+                   (addr ?omb ?contents)
+                   (know-addr-of ?omb))
+              (                           ;ordered
+               (find-mem-block ?mb)
+               (!ace2-set-pointer-to-buffer ?mbptr ?omb ?contents)))
+
+            (:method (write-mem-block-contents ?mb ?contents)
+              use-two-sysctl-writes
+              (and (sysctl-table-entry ?ste1)
+                   (not (used-in-chain ?ste1))
+                   (sysctl-table-entry ?ste2)
+                   (not (used-in-chain ?ste2))
+                   (not (= ?ste1 ?ste2))
+                   (ste-data-addr ?ste1 ?ste-addr1)
+                   (ste-procname ?ste1 ?procname)
+                   (ste-data-addr ?ste2 ?_ste-addr2)
+                   (ste-procname ?ste2 ?_procname2)
+                   (addr ?mb ?mb-addr)
+                   )
+              (:ordered (!!assert (used-in-chain ?ste1))
+                        (find-mem-block ?ste1)
+                        (find-mem-block ?ste2)
+                        (write-mem-block-contents ?ste1 ?mb-addr)
+                        (!sysctl-write ?procname ?contents ?ste1
+                                       ?ste-addr1 ?mb ?mb-addr)))
+
+            (:method (find-mem-block ?mb)
+              mb-addr-already-known
+              (or (know-addr-of ?mb)
+                  (ste-know-addr-of ?mb))
+              ()
+              mb-needs-finding
+              ((mem-block ?mb))
+              (!compute-memory-block-addr-using-dmesg ?mb)
+              ste-entry-needs-finding
+              ((sysctl-table-entry ?mb))
+              (!compute-sysctl-table-entry-addr ?mb))
+
+            (:op (!!assert ?x)
+             :add (?x))
+
+            (:op (!!query (?x))
+             :precond (?x))
+
+            (:op (!!format . ?rest)
+             :precond (eval (progn
+                              (apply #'format t '?rest)
+                              t))))))
+    (let ((new-plan-tree-tests::prob (MAKE-PROBLEM '(GP-PROBLEM :domain test-hopping :redefine-ok t)
+                             '((ADDR MEM-BLOCK-CORE-PATTERN-BUFFER ADDR4780926)
+                               (ADDR MEM-BLOCK-CORE-PATTERN-BUFFER-PLUS-2
+                                ADDR-CORE-PAT-PLUS-2)
+                               (ADDR MEM-BLOCK-CORE_PIPE_LIMIT_BUFFER ADDR4780930)
+                               (ADDR MEM-BLOCK-CORE_USES_PID_BUFFER ADDR4780928)
+                               (ADDR MEM-BLOCK-IO_URING_GROUP_BUFFER ADDR4780932)
+                               (ADDR MEM-BLOCK-MAX_LOCK_DEPTH_BUFFER ADDR4780934)
+                               (ADDR MEM-BLOCK-OOPS_LIMIT_BUFFER ADDR4780936)
+                               (ADDR MEM-BLOCK-PANIC_BUFFER ADDR4780940)
+                               (ADDR MEM-BLOCK-PANIC_ON_OOPS_BUFFER ADDR4780938)
+                               (ADDR MEM-BLOCK-PERF_EVENT_MLOCK_KB_BUFFER ADDR4780942)
+                               (ADDR MEM-BLOCK-PERF_EVENT_PARANOID_BUFFER ADDR4780944)
+                               (ADDR MEM-BLOCK-PRINTK_BUFFER ADDR4780946)
+                               (ADDR MEM-BLOCK-PRINTK_RATELIMIT_BURST_BUFFER
+                                ADDR4780948)
+                               (ADDR MEM-BLOCK-RANDOMIZE_VA_SPACE_BUFFER ADDR4780950)
+                               (ADDR MEM-BLOCK-WARN_LIMIT_BUFFER ADDR4780952)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_CORE_PATTERN
+                                ADDR4780925)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_CORE_PIPE_LIMIT
+                                ADDR4780929)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_CORE_USES_PID
+                                ADDR4780927)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_IO_URING_GROUP
+                                ADDR4780931)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_MAX_LOCK_DEPTH
+                                ADDR4780933)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_OOPS_LIMIT ADDR4780935)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_PANIC ADDR4780939)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_PANIC_ON_OOPS
+                                ADDR4780937)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB
+                                ADDR4780941)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_PARANOID
+                                ADDR4780943)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_PRINTK ADDR4780945)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST
+                                ADDR4780947)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE
+                                ADDR4780949)
+                               (ADDR PTR-STE-STRING_KERNEL_DOT_WARN_LIMIT ADDR4780951)
+                               (ADDRESS ADDR-CORE-PAT-PLUS-2) (ADDRESS ADDR4780925)
+                               (ADDRESS ADDR4780926) (ADDRESS ADDR4780927)
+                               (ADDRESS ADDR4780928) (ADDRESS ADDR4780929)
+                               (ADDRESS ADDR4780930) (ADDRESS ADDR4780931)
+                               (ADDRESS ADDR4780932) (ADDRESS ADDR4780933)
+                               (ADDRESS ADDR4780934) (ADDRESS ADDR4780935)
+                               (ADDRESS ADDR4780936) (ADDRESS ADDR4780937)
+                               (ADDRESS ADDR4780938) (ADDRESS ADDR4780939)
+                               (ADDRESS ADDR4780940) (ADDRESS ADDR4780941)
+                               (ADDRESS ADDR4780942) (ADDRESS ADDR4780943)
+                               (ADDRESS ADDR4780944) (ADDRESS ADDR4780945)
+                               (ADDRESS ADDR4780946) (ADDRESS ADDR4780947)
+                               (ADDRESS ADDR4780948) (ADDRESS ADDR4780949)
+                               (ADDRESS ADDR4780950) (ADDRESS ADDR4780951)
+                               (ADDRESS ADDR4780952)
+                               (ADDRESSABLE MEM-BLOCK-BUFF-TARGET)
+                               (ADDRESSABLE MEM-BLOCK-CORE-PATTERN-BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-CORE-PATTERN-BUFFER-PLUS-2)
+                               (ADDRESSABLE MEM-BLOCK-CORE_PIPE_LIMIT_BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-CORE_USES_PID_BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-IO_URING_GROUP_BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-MAX_LOCK_DEPTH_BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-OOPS_LIMIT_BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-PANIC_BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-PANIC_ON_OOPS_BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-PERF_EVENT_MLOCK_KB_BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-PERF_EVENT_PARANOID_BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-PRINTK_BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-PRINTK_RATELIMIT_BURST_BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-RANDOMIZE_VA_SPACE_BUFFER)
+                               (ADDRESSABLE MEM-BLOCK-WARN_LIMIT_BUFFER)
+                               (ADDRESSABLE PTR-STE-STRING_KERNEL_DOT_CORE_PATTERN)
+                               (ADDRESSABLE PTR-STE-STRING_KERNEL_DOT_CORE_PIPE_LIMIT)
+                               (ADDRESSABLE PTR-STE-STRING_KERNEL_DOT_CORE_USES_PID)
+                               (ADDRESSABLE PTR-STE-STRING_KERNEL_DOT_IO_URING_GROUP)
+                               (ADDRESSABLE PTR-STE-STRING_KERNEL_DOT_MAX_LOCK_DEPTH)
+                               (ADDRESSABLE PTR-STE-STRING_KERNEL_DOT_OOPS_LIMIT)
+                               (ADDRESSABLE PTR-STE-STRING_KERNEL_DOT_PANIC)
+                               (ADDRESSABLE PTR-STE-STRING_KERNEL_DOT_PANIC_ON_OOPS)
+                               (ADDRESSABLE
+                                PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB)
+                               (ADDRESSABLE
+                                PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_PARANOID)
+                               (ADDRESSABLE PTR-STE-STRING_KERNEL_DOT_PRINTK)
+                               (ADDRESSABLE
+                                PTR-STE-STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST)
+                               (ADDRESSABLE
+                                PTR-STE-STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE)
+                               (ADDRESSABLE PTR-STE-STRING_KERNEL_DOT_WARN_LIMIT)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_CORE_PATTERN)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_CORE_PIPE_LIMIT)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_CORE_USES_PID)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_IO_URING_GROUP)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_MAX_LOCK_DEPTH)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_OOPS_LIMIT)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_PANIC)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_PANIC_ON_OOPS)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_PERF_EVENT_PARANOID)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_PRINTK)
+                               (ADDRESSABLE
+                                STE-STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE)
+                               (ADDRESSABLE STE-STRING_KERNEL_DOT_WARN_LIMIT)
+                               (DMESG-OBSERVABLE MEM-BLOCK-CORE-PATTERN-BUFFER)
+                               (DMESG-OBSERVABLE MEM-BLOCK-CORE_PIPE_LIMIT_BUFFER)
+                               (DMESG-OBSERVABLE MEM-BLOCK-CORE_USES_PID_BUFFER)
+                               (DMESG-OBSERVABLE MEM-BLOCK-IO_URING_GROUP_BUFFER)
+                               (DMESG-OBSERVABLE MEM-BLOCK-MAX_LOCK_DEPTH_BUFFER)
+                               (DMESG-OBSERVABLE MEM-BLOCK-OOPS_LIMIT_BUFFER)
+                               (DMESG-OBSERVABLE MEM-BLOCK-PANIC_BUFFER)
+                               (DMESG-OBSERVABLE MEM-BLOCK-PANIC_ON_OOPS_BUFFER)
+                               (DMESG-OBSERVABLE MEM-BLOCK-PERF_EVENT_MLOCK_KB_BUFFER)
+                               (DMESG-OBSERVABLE MEM-BLOCK-PERF_EVENT_PARANOID_BUFFER)
+                               (DMESG-OBSERVABLE MEM-BLOCK-PRINTK_BUFFER)
+                               (DMESG-OBSERVABLE
+                                MEM-BLOCK-PRINTK_RATELIMIT_BURST_BUFFER)
+                               (DMESG-OBSERVABLE MEM-BLOCK-RANDOMIZE_VA_SPACE_BUFFER)
+                               (DMESG-OBSERVABLE MEM-BLOCK-WARN_LIMIT_BUFFER)
+                               (DMESG-OBSERVABLE
+                                PTR-STE-STRING_KERNEL_DOT_CORE_PATTERN)
+                               (DMESG-OBSERVABLE
+                                PTR-STE-STRING_KERNEL_DOT_CORE_PIPE_LIMIT)
+                               (DMESG-OBSERVABLE
+                                PTR-STE-STRING_KERNEL_DOT_CORE_USES_PID)
+                               (DMESG-OBSERVABLE
+                                PTR-STE-STRING_KERNEL_DOT_IO_URING_GROUP)
+                               (DMESG-OBSERVABLE
+                                PTR-STE-STRING_KERNEL_DOT_MAX_LOCK_DEPTH)
+                               (DMESG-OBSERVABLE PTR-STE-STRING_KERNEL_DOT_OOPS_LIMIT)
+                               (DMESG-OBSERVABLE PTR-STE-STRING_KERNEL_DOT_PANIC)
+                               (DMESG-OBSERVABLE
+                                PTR-STE-STRING_KERNEL_DOT_PANIC_ON_OOPS)
+                               (DMESG-OBSERVABLE
+                                PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB)
+                               (DMESG-OBSERVABLE
+                                PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_PARANOID)
+                               (DMESG-OBSERVABLE PTR-STE-STRING_KERNEL_DOT_PRINTK)
+                               (DMESG-OBSERVABLE
+                                PTR-STE-STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST)
+                               (DMESG-OBSERVABLE
+                                PTR-STE-STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE)
+                               (DMESG-OBSERVABLE PTR-STE-STRING_KERNEL_DOT_WARN_LIMIT)
+                               (DMESG-RUNNING)
+                               (:GOAL (ATTACKER-OWNS-CORE-DUMP PROC-PROC-TARGET))
+                               (HAVE-ROOT) (MEM-BLOCK MEM-BLOCK-BUFF-TARGET)
+                               (MEM-BLOCK MEM-BLOCK-BUFF-TARGET)
+                               (MEM-BLOCK MEM-BLOCK-CORE-PATTERN-BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-CORE-PATTERN-BUFFER-PLUS-2)
+                               (MEM-BLOCK MEM-BLOCK-CORE_PIPE_LIMIT_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-CORE_PIPE_LIMIT_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-CORE_USES_PID_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-CORE_USES_PID_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-IO_URING_GROUP_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-IO_URING_GROUP_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-MAX_LOCK_DEPTH_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-MAX_LOCK_DEPTH_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-OOPS_LIMIT_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-OOPS_LIMIT_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-PANIC_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-PANIC_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-PANIC_ON_OOPS_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-PANIC_ON_OOPS_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-PERF_EVENT_MLOCK_KB_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-PERF_EVENT_MLOCK_KB_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-PERF_EVENT_PARANOID_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-PERF_EVENT_PARANOID_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-PRINTK_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-PRINTK_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-PRINTK_RATELIMIT_BURST_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-PRINTK_RATELIMIT_BURST_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-RANDOMIZE_VA_SPACE_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-RANDOMIZE_VA_SPACE_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-WARN_LIMIT_BUFFER)
+                               (MEM-BLOCK MEM-BLOCK-WARN_LIMIT_BUFFER)
+                               (MEM-BLOCK PTR-STE-STRING_KERNEL_DOT_CORE_PATTERN)
+                               (MEM-BLOCK PTR-STE-STRING_KERNEL_DOT_CORE_PIPE_LIMIT)
+                               (MEM-BLOCK PTR-STE-STRING_KERNEL_DOT_CORE_USES_PID)
+                               (MEM-BLOCK PTR-STE-STRING_KERNEL_DOT_IO_URING_GROUP)
+                               (MEM-BLOCK PTR-STE-STRING_KERNEL_DOT_MAX_LOCK_DEPTH)
+                               (MEM-BLOCK PTR-STE-STRING_KERNEL_DOT_OOPS_LIMIT)
+                               (MEM-BLOCK PTR-STE-STRING_KERNEL_DOT_PANIC)
+                               (MEM-BLOCK PTR-STE-STRING_KERNEL_DOT_PANIC_ON_OOPS)
+                               (MEM-BLOCK
+                                PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB)
+                               (MEM-BLOCK
+                                PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_PARANOID)
+                               (MEM-BLOCK PTR-STE-STRING_KERNEL_DOT_PRINTK)
+                               (MEM-BLOCK
+                                PTR-STE-STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST)
+                               (MEM-BLOCK
+                                PTR-STE-STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE)
+                               (MEM-BLOCK PTR-STE-STRING_KERNEL_DOT_WARN_LIMIT)
+                               (MEM-BLOCK-CONTENTS MEM-BLOCK-BUFF-TARGET TARGET-MEM)
+                               (MEM-BLOCK-CONTENTS MEM-BLOCK-CORE-PATTERN-BUFFER
+                                EMPTY)
+                               (MEM-BLOCK-CONTENTS
+                                MEM-BLOCK-CORE-PATTERN-BUFFER-PLUS-2 EMPTY)
+                               (MEM-BLOCK-CONTENTS MEM-BLOCK-CORE_PIPE_LIMIT_BUFFER
+                                EMPTY)
+                               (MEM-BLOCK-CONTENTS MEM-BLOCK-CORE_USES_PID_BUFFER
+                                EMPTY)
+                               (MEM-BLOCK-CONTENTS MEM-BLOCK-IO_URING_GROUP_BUFFER
+                                EMPTY)
+                               (MEM-BLOCK-CONTENTS MEM-BLOCK-MAX_LOCK_DEPTH_BUFFER
+                                EMPTY)
+                               (MEM-BLOCK-CONTENTS MEM-BLOCK-OOPS_LIMIT_BUFFER EMPTY)
+                               (MEM-BLOCK-CONTENTS MEM-BLOCK-PANIC_BUFFER EMPTY)
+                               (MEM-BLOCK-CONTENTS MEM-BLOCK-PANIC_ON_OOPS_BUFFER
+                                EMPTY)
+                               (MEM-BLOCK-CONTENTS
+                                MEM-BLOCK-PERF_EVENT_MLOCK_KB_BUFFER EMPTY)
+                               (MEM-BLOCK-CONTENTS
+                                MEM-BLOCK-PERF_EVENT_PARANOID_BUFFER EMPTY)
+                               (MEM-BLOCK-CONTENTS MEM-BLOCK-PRINTK_BUFFER EMPTY)
+                               (MEM-BLOCK-CONTENTS
+                                MEM-BLOCK-PRINTK_RATELIMIT_BURST_BUFFER EMPTY)
+                               (MEM-BLOCK-CONTENTS MEM-BLOCK-RANDOMIZE_VA_SPACE_BUFFER
+                                EMPTY)
+                               (MEM-BLOCK-CONTENTS MEM-BLOCK-WARN_LIMIT_BUFFER EMPTY)
+                               (MEM-BLOCK-CONTENTS
+                                PTR-STE-STRING_KERNEL_DOT_CORE_PATTERN ADDR4780926)
+                               (MEM-BLOCK-CONTENTS
+                                PTR-STE-STRING_KERNEL_DOT_CORE_PIPE_LIMIT ADDR4780930)
+                               (MEM-BLOCK-CONTENTS
+                                PTR-STE-STRING_KERNEL_DOT_CORE_USES_PID ADDR4780928)
+                               (MEM-BLOCK-CONTENTS
+                                PTR-STE-STRING_KERNEL_DOT_IO_URING_GROUP ADDR4780932)
+                               (MEM-BLOCK-CONTENTS
+                                PTR-STE-STRING_KERNEL_DOT_MAX_LOCK_DEPTH ADDR4780934)
+                               (MEM-BLOCK-CONTENTS
+                                PTR-STE-STRING_KERNEL_DOT_OOPS_LIMIT ADDR4780936)
+                               (MEM-BLOCK-CONTENTS PTR-STE-STRING_KERNEL_DOT_PANIC
+                                ADDR4780940)
+                               (MEM-BLOCK-CONTENTS
+                                PTR-STE-STRING_KERNEL_DOT_PANIC_ON_OOPS ADDR4780938)
+                               (MEM-BLOCK-CONTENTS
+                                PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB
+                                ADDR4780942)
+                               (MEM-BLOCK-CONTENTS
+                                PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_PARANOID
+                                ADDR4780944)
+                               (MEM-BLOCK-CONTENTS PTR-STE-STRING_KERNEL_DOT_PRINTK
+                                ADDR4780946)
+                               (MEM-BLOCK-CONTENTS
+                                PTR-STE-STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST
+                                ADDR4780948)
+                               (MEM-BLOCK-CONTENTS
+                                PTR-STE-STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE
+                                ADDR4780950)
+                               (MEM-BLOCK-CONTENTS
+                                PTR-STE-STRING_KERNEL_DOT_WARN_LIMIT ADDR4780952)
+                               (OBJECT EMPTY) (OBJECT TARGET-MEM)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_CORE_PATTERN)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_CORE_PIPE_LIMIT)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_CORE_USES_PID)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_IO_URING_GROUP)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_MAX_LOCK_DEPTH)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_OOPS_LIMIT)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_PANIC)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_PANIC_ON_OOPS)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_PARANOID)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_PRINTK)
+                               (POINTER
+                                PTR-STE-STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE)
+                               (POINTER PTR-STE-STRING_KERNEL_DOT_WARN_LIMIT)
+                               (PROC-CONTAINS PROC-PROC-TARGET MEM-BLOCK-BUFF-TARGET)
+                               (PROC-STATE PROC-PROC-TARGET PS-RUNNING)
+                               (PROCESS PROC-PROC-TARGET)
+                               (PROCNAME STRING_KERNEL_DOT_CORE_PIPE_LIMIT)
+                               (PROCNAME STRING_KERNEL_DOT_CORE_USES_PID)
+                               (PROCNAME STRING_KERNEL_DOT_IO_URING_GROUP)
+                               (PROCNAME STRING_KERNEL_DOT_MAX_LOCK_DEPTH)
+                               (PROCNAME STRING_KERNEL_DOT_OOPS_LIMIT)
+                               (PROCNAME STRING_KERNEL_DOT_PANIC)
+                               (PROCNAME STRING_KERNEL_DOT_PANIC_ON_OOPS)
+                               (PROCNAME STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB)
+                               (PROCNAME STRING_KERNEL_DOT_PERF_EVENT_PARANOID)
+                               (PROCNAME STRING_KERNEL_DOT_PRINTK)
+                               (PROCNAME STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST)
+                               (PROCNAME STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE)
+                               (PROCNAME STRING_KERNEL_DOT_WARN_LIMIT)
+                               (STE-DATA-ADDR STE-STRING_KERNEL_DOT_CORE_PATTERN
+                                PTR-STE-STRING_KERNEL_DOT_CORE_PATTERN)
+                               (STE-DATA-ADDR STE-STRING_KERNEL_DOT_CORE_PIPE_LIMIT
+                                PTR-STE-STRING_KERNEL_DOT_CORE_PIPE_LIMIT)
+                               (STE-DATA-ADDR STE-STRING_KERNEL_DOT_CORE_USES_PID
+                                PTR-STE-STRING_KERNEL_DOT_CORE_USES_PID)
+                               (STE-DATA-ADDR STE-STRING_KERNEL_DOT_IO_URING_GROUP
+                                PTR-STE-STRING_KERNEL_DOT_IO_URING_GROUP)
+                               (STE-DATA-ADDR STE-STRING_KERNEL_DOT_MAX_LOCK_DEPTH
+                                PTR-STE-STRING_KERNEL_DOT_MAX_LOCK_DEPTH)
+                               (STE-DATA-ADDR STE-STRING_KERNEL_DOT_OOPS_LIMIT
+                                PTR-STE-STRING_KERNEL_DOT_OOPS_LIMIT)
+                               (STE-DATA-ADDR STE-STRING_KERNEL_DOT_PANIC
+                                PTR-STE-STRING_KERNEL_DOT_PANIC)
+                               (STE-DATA-ADDR STE-STRING_KERNEL_DOT_PANIC_ON_OOPS
+                                PTR-STE-STRING_KERNEL_DOT_PANIC_ON_OOPS)
+                               (STE-DATA-ADDR
+                                STE-STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB
+                                PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB)
+                               (STE-DATA-ADDR
+                                STE-STRING_KERNEL_DOT_PERF_EVENT_PARANOID
+                                PTR-STE-STRING_KERNEL_DOT_PERF_EVENT_PARANOID)
+                               (STE-DATA-ADDR STE-STRING_KERNEL_DOT_PRINTK
+                                PTR-STE-STRING_KERNEL_DOT_PRINTK)
+                               (STE-DATA-ADDR
+                                STE-STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST
+                                PTR-STE-STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST)
+                               (STE-DATA-ADDR STE-STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE
+                                PTR-STE-STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE)
+                               (STE-DATA-ADDR STE-STRING_KERNEL_DOT_WARN_LIMIT
+                                PTR-STE-STRING_KERNEL_DOT_WARN_LIMIT)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_CORE_PATTERN
+                                STRING_KERNEL_DOT_CORE_PATTERN)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_CORE_PIPE_LIMIT
+                                STRING_KERNEL_DOT_CORE_PIPE_LIMIT)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_CORE_USES_PID
+                                STRING_KERNEL_DOT_CORE_USES_PID)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_IO_URING_GROUP
+                                STRING_KERNEL_DOT_IO_URING_GROUP)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_MAX_LOCK_DEPTH
+                                STRING_KERNEL_DOT_MAX_LOCK_DEPTH)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_OOPS_LIMIT
+                                STRING_KERNEL_DOT_OOPS_LIMIT)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_PANIC
+                                STRING_KERNEL_DOT_PANIC)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_PANIC_ON_OOPS
+                                STRING_KERNEL_DOT_PANIC_ON_OOPS)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB
+                                STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_PERF_EVENT_PARANOID
+                                STRING_KERNEL_DOT_PERF_EVENT_PARANOID)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_PRINTK
+                                STRING_KERNEL_DOT_PRINTK)
+                               (STE-PROCNAME
+                                STE-STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST
+                                STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE
+                                STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE)
+                               (STE-PROCNAME STE-STRING_KERNEL_DOT_WARN_LIMIT
+                                STRING_KERNEL_DOT_WARN_LIMIT)
+                               (SYSCTL-TABLE-ENTRY STE-STRING_KERNEL_DOT_CORE_PATTERN)
+                               (SYSCTL-TABLE-ENTRY
+                                STE-STRING_KERNEL_DOT_CORE_PIPE_LIMIT)
+                               (SYSCTL-TABLE-ENTRY
+                                STE-STRING_KERNEL_DOT_CORE_USES_PID)
+                               (SYSCTL-TABLE-ENTRY
+                                STE-STRING_KERNEL_DOT_IO_URING_GROUP)
+                               (SYSCTL-TABLE-ENTRY
+                                STE-STRING_KERNEL_DOT_MAX_LOCK_DEPTH)
+                               (SYSCTL-TABLE-ENTRY STE-STRING_KERNEL_DOT_OOPS_LIMIT)
+                               (SYSCTL-TABLE-ENTRY STE-STRING_KERNEL_DOT_PANIC)
+                               (SYSCTL-TABLE-ENTRY
+                                STE-STRING_KERNEL_DOT_PANIC_ON_OOPS)
+                               (SYSCTL-TABLE-ENTRY
+                                STE-STRING_KERNEL_DOT_PERF_EVENT_MLOCK_KB)
+                               (SYSCTL-TABLE-ENTRY
+                                STE-STRING_KERNEL_DOT_PERF_EVENT_PARANOID)
+                               (SYSCTL-TABLE-ENTRY STE-STRING_KERNEL_DOT_PRINTK)
+                               (SYSCTL-TABLE-ENTRY
+                                STE-STRING_KERNEL_DOT_PRINTK_RATELIMIT_BURST)
+                               (SYSCTL-TABLE-ENTRY
+                                STE-STRING_KERNEL_DOT_RANDOMIZE_VA_SPACE)
+                               (SYSCTL-TABLE-ENTRY STE-STRING_KERNEL_DOT_WARN_LIMIT))
+                             '(:TASK WIN))))
+    ,@body)))
+
+(in-package :new-plan-tree-tests)
+
+(defun check-single-plan-tree-internal (tree plan)
+  (let* ((plan-no-costs (shop:remove-costs plan))
+         (primitive-tasks
+           (remove-if #'(lambda (x) (eq (task-name x) 'shop::!!inop))
+                      (mapcar #'(lambda (n) (or (plan-tree:tree-node-task n)
+                                                (plan-tree:tree-node-expanded-task n)))
+                              (all-primitive-nodes tree)))))
+    (is (typep tree 'plan-tree:top-node))
+    (is (= 1 (length (plan-tree:complex-tree-node-children tree))))
+    (is (equalp '(shop3-user::win)
+                (plan-tree:tree-node-task (first (plan-tree:complex-tree-node-children tree)))))
+    (is (alexandria:set-equal plan-no-costs
+                              primitive-tasks
+                              :test 'equalp)
+        "Plan is not set-equal to the set of primitive nodes of the tree:~%
+ Actions not in the tree:~%~s~%
+ Tree nodes not in the plan:~%~s~%"
+        (set-difference plan-no-costs primitive-tasks :test #'equalp)
+        (set-difference primitive-tasks plan-no-costs :test #'equalp))))
+
+(test check-single-plan-tree ;; 8 checks
+  (test-hopping-domain
+    ;; finding just one plan
+    (multiple-value-bind (plans trees states)
+        (find-plans-stack prob :plan-tree t :which :first)
+      (5am:is-true plans)
+      (5am:is-true trees)
+      (5am:is-true states)
+      (is (= (length plans) (length trees) (length states) 1))
+      (check-single-plan-tree-internal (first trees) (first plans)))))
+
+(test check-all-plan-trees ; 680 checks
+  (test-hopping-domain
+    ;; finding all the plans
+    (multiple-value-bind (plans trees states)
+        (find-plans-stack prob :plan-tree t :which :all)
+      (5am:is-true plans)
+      (5am:is-true trees)
+      (5am:is-true states)
+      (is (= 169 (length plans) (length trees) (length states))
+          "There are ~d plans ~d trees and ~d states"
+           (length plans) (length trees) (length states))
+      (mapcar #'check-single-plan-tree-internal trees plans))))
+
+(test check-multiple-plan-trees ; 12 checks
+  (test-hopping-domain
+    ;; finding more than one, but less than all plans
+    (multiple-value-bind (plans trees states)
+        (find-plans-stack prob :plan-tree t :which :first :plan-num-limit 2)
+      (5am:is-true plans)
+      (5am:is-true trees)
+      (5am:is-true states)
+      (is (= 2 (length plans) (length trees) (length states))
+          "There are ~d plans ~d trees and ~d states"
+           (length plans) (length trees) (length states))
+      (mapcar #'check-single-plan-tree-internal trees plans))))

--- a/shop3/tests/st-test-domain.pddl
+++ b/shop3/tests/st-test-domain.pddl
@@ -1,0 +1,106 @@
+; -*- domain-file: t; -*-
+
+(define (domain ste-test-domain)
+ (:requirements :adl)
+ (:types
+   mem-block - addressable
+   process - object
+   address - object
+   pointer - mem-block
+   sysctl-table-entry - addressable
+   addressable - object
+   mem-len - object
+   procname - object)
+ (:constants
+   ps-not-started - object
+   ps-running - object
+   ps-clean-exit - object
+   ps-crash - object
+   mem-block-core-pattern-buffer - mem-block
+   mem-block-core-pattern-buffer-plus-2 - mem-block
+   corrupt-path - object
+   string_kernel_dot_core_pattern - procname)
+ (:predicates (mem-block ?mb - mem-block) (block-size ?mb - mem-block)
+  (attacker-controls ?mb - mem-block)
+  (mem-block-contents ?mb - mem-block ?s - object)
+  (proc-contains ?proc - process ?mb - mem-block)
+  (proc-state ?proc - process ?ps - object) (address-p ?a - address)
+  (ste-procname ?ste - sysctl-table-entry ?pn - procname)
+  (ste-data-addr ?ste - sysctl-table-entry ?b - mem-block)
+  (ste-data-mem-block ?ste - sysctl-table-entry ?b - mem-block)
+  (ste-maxlen ?ste - sysctl-table-entry ?len - mem-len)
+  (addressable ?obj - addressable) (addr ?obj - addressable ?a - address)
+  (know-addr-of ?obj - addressable) (dmesg-observable ?obj - addressable)
+  (ace2-used) (have-root) (dmesg-running) (waiting-to-observe ?thing - object)
+  (win) (attacker-owns-core-dump ?process - process))
+ (:action compute-sysctl-table-entry-addr :parameters
+  (?ste - sysctl-table-entry) :precondition
+  (and
+    (have-root)
+    (dmesg-running)
+    (not (know-addr-of ?ste)))
+  :effect
+  (and
+    (forall (?x - pointer)
+      (when
+        (ste-data-addr ?ste ?x)
+        (know-addr-of ?x)))
+    (know-addr-of ?ste)))
+ (:action compute-memory-block-addr-using-dmesg :parameters
+  (?memory-block - mem-block) :precondition
+  (and
+    (have-root)
+    (dmesg-running)
+    (dmesg-observable ?memory-block))
+  :effect
+  (and
+    (know-addr-of ?memory-block)))
+ (:action compute-mem-block-addr-core-pat-plus-2
+   :parameters
+   (?core-pat-buff - mem-block ?core-pat-buff-plus-2 - mem-block)
+   :precondition
+   (and
+    (= ?core-pat-buff mem-block-core-pattern-buffer)
+    (= ?core-pat-buff-plus-2 mem-block-core-pattern-buffer-plus-2)
+    (know-addr-of ?core-pat-buff))
+   :effect
+   (and
+    (know-addr-of ?core-pat-buff-plus-2)))
+ (:action ace2-set-pointer-to-buffer :parameters
+  (?ptr - pointer ?mb - mem-block ?addr-mb - address) :precondition
+  (and
+    (know-addr-of ?ptr)
+    (know-addr-of ?mb)
+    (not (ace2-used))
+    (addr ?mb ?addr-mb))
+  :effect
+  (and
+    (mem-block-contents ?ptr ?addr-mb)
+    (ace2-used)))
+ (:action sysctl-write
+   :parameters
+  (?procname - procname
+             ?new-contents - object
+             ?ste - sysctl-table-entry
+             ?ptr - pointer
+             ?mb - mem-block
+             ?a - address)
+  :precondition
+  (and
+    (ste-procname ?ste ?procname)
+    (ste-data-addr ?ste ?ptr)
+    (mem-block-contents ?ptr ?a)
+    (addr ?mb ?a)
+    (know-addr-of ?mb)
+    (not (= ?procname string_kernel_dot_core_pattern)))
+  :effect
+  (and
+    (mem-block-contents ?mb ?new-contents)))
+ (:action kill-process :parameters (?process - process) :precondition
+  (and
+    (mem-block-contents mem-block-core-pattern-buffer-plus-2 corrupt-path)
+    (proc-state ?process ps-running))
+  :effect
+  (and
+    (proc-state ?process ps-crash)
+    (attacker-owns-core-dump ?process))))

--- a/shop3/unification/tracer.lisp
+++ b/shop3/unification/tracer.lisp
@@ -72,10 +72,11 @@
     nil))
 
 (defmacro trace-print (type item state &rest formats)
-  `(progn
+  `(when *shop-trace*
      (unless (symbolp ,item)
        (error 'type-error :expected-type 'symbol :datum ,item))
-     (when (or (member ,type *shop-trace*) (member ,item *shop-trace*)
+     (when (or (member ,type *shop-trace*)
+               (member ,item *shop-trace*)
                (trigger-trace ,type ,item))
        ,(let ((cpack (find-package :shop2.common)))
           (when cpack


### PR DESCRIPTION
The logic for copying plan trees, to avoid issues with multiple plan tree returns, was incorrect.  H/T to @mpatsift for finding this.

Note that this is being fixed for the *enhanced* plan trees returned by `find-plans-stack`.

The copying is subtle because the tasks in the plan tree share structure with the tasks in the plan.


Fixes #177 